### PR TITLE
Fix bar recent marquee width and remove unintended CRT highlight

### DIFF
--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useState, useCallback, useEffect, useRef, useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 
-import { defaultOverlaySettings, type OverlaySettings } from '../server/shared/overlaySettings';
+import { defaultOverlaySettings, normalizeBarSections, type OverlaySettings } from '../server/shared/overlaySettings';
 
 // Full settings including auth token (kept for backwards compat with consumers)
 export interface Settings extends OverlaySettings {
@@ -159,8 +159,7 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children }) 
         ...(cached.perOverlayFontSize ?? {}),
       },
       barSections: {
-        ...defaultOverlaySettings.barSections,
-        ...(cached.barSections ?? {}),
+        ...normalizeBarSections(cached.barSections),
       },
       themeSettings: {
         ...defaultOverlaySettings.themeSettings,
@@ -245,7 +244,7 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children }) 
           const merged: OverlaySettings = {
             ...defaultOverlaySettings,
             ...fetched,
-            barSections: { ...defaultOverlaySettings.barSections, ...(fetched.barSections ?? {}) },
+            barSections: normalizeBarSections(fetched.barSections),
             themeSettings: {
               ...defaultOverlaySettings.themeSettings,
               ...(fetched.themeSettings ?? {}),

--- a/src/contexts/TwitchContext.tsx
+++ b/src/contexts/TwitchContext.tsx
@@ -77,6 +77,7 @@ interface TwitchContextType {
   lastFollower: TwitchFollower | null;
   lastSubscriber: TwitchSubscriber | null;
   followerCount: number;
+  subscriberCount: number;
   clearMessages: () => void;
   getEmoteByName: (name: string) => CachedEmote | undefined;
 }
@@ -148,6 +149,7 @@ export const TwitchProvider: TwitchProviderComponent = ({ children }) => {
   const [lastFollower, setLastFollower] = useState<TwitchFollower | null>(null);
   const [lastSubscriber, setLastSubscriber] = useState<TwitchSubscriber | null>(null);
   const [followerCount, setFollowerCount] = useState(0);
+  const [subscriberCount, setSubscriberCount] = useState(0);
 
   const [cachedEmotes, setCachedEmotes] = useState<Map<string, CachedEmote>>(new Map());
   const emotesLoadedRef = useRef<string>('');
@@ -205,6 +207,8 @@ export const TwitchProvider: TwitchProviderComponent = ({ children }) => {
   const fetchSubscribers = useCallback(async () => {
     const data = await fetchApi<{ data: TwitchSubscriberData[]; total: number }>('subscribers');
     if (!data) return;
+
+    setSubscriberCount(data.total ?? 0);
 
     if (data.data.length > 0) {
       const s = data.data[0];
@@ -328,6 +332,7 @@ export const TwitchProvider: TwitchProviderComponent = ({ children }) => {
     lastFollower,
     lastSubscriber,
     followerCount,
+    subscriberCount,
     clearMessages,
     getEmoteByName,
   };

--- a/src/pages/AuthSuccessPage.tsx
+++ b/src/pages/AuthSuccessPage.tsx
@@ -392,7 +392,7 @@ export default function AuthSuccessPage() {
                       ['clock', 'Current Time'],
                       ['duration', 'Stream Duration'],
                       ['title', 'Stream Title / Category'],
-                      ['stats', 'Viewers & Followers'],
+                      ['stats', 'Stream Stats (Viewers / Followers / Subscribers)'],
                       ['recentFollower', 'Last Follower'],
                       ['recentSub', 'Last Subscriber'],
                     ] as const

--- a/src/pages/AuthSuccessPage.tsx
+++ b/src/pages/AuthSuccessPage.tsx
@@ -392,7 +392,9 @@ export default function AuthSuccessPage() {
                       ['clock', 'Current Time'],
                       ['duration', 'Stream Duration'],
                       ['title', 'Stream Title / Category'],
-                      ['stats', 'Stream Stats (Viewers / Followers / Subscribers)'],
+                      ['viewers', 'Viewers'],
+                      ['followers', 'Followers'],
+                      ['subscribers', 'Subscribers'],
                       ['recentFollower', 'Last Follower'],
                       ['recentSub', 'Last Subscriber'],
                     ] as const

--- a/src/pages/overlay/BarOverlay.tsx
+++ b/src/pages/overlay/BarOverlay.tsx
@@ -140,9 +140,9 @@ const BarOverlayContent = () => {
       { key: 'clock', enabled: settings.barSections.clock, minWidth: 114, dropRank: 3 },
       { key: 'duration', enabled: settings.barSections.duration, minWidth: 132, dropRank: 4 },
       { key: 'title', enabled: settings.barSections.title, minWidth: 148, dropRank: 0, keep: true },
-      { key: 'viewers', enabled: settings.barSections.stats, minWidth: 92, dropRank: 2 },
-      { key: 'followers', enabled: settings.barSections.stats, minWidth: 92, dropRank: 5 },
-      { key: 'subscribers', enabled: settings.barSections.stats, minWidth: 102, dropRank: 6 },
+      { key: 'viewers', enabled: settings.barSections.viewers, minWidth: 92, dropRank: 2 },
+      { key: 'followers', enabled: settings.barSections.followers, minWidth: 92, dropRank: 5 },
+      { key: 'subscribers', enabled: settings.barSections.subscribers, minWidth: 102, dropRank: 6 },
       { key: 'recentFollower', enabled: settings.barSections.recentFollower && !!twitch.lastFollower, minWidth: 144, dropRank: 1 },
       { key: 'recentSub', enabled: settings.barSections.recentSub && !!twitch.lastSubscriber, minWidth: 144, dropRank: 7 },
     ];
@@ -179,7 +179,9 @@ const BarOverlayContent = () => {
     settings.barSections.clock,
     settings.barSections.duration,
     settings.barSections.title,
-    settings.barSections.stats,
+    settings.barSections.viewers,
+    settings.barSections.followers,
+    settings.barSections.subscribers,
     settings.barSections.recentFollower,
     settings.barSections.recentSub,
     twitch.lastFollower,
@@ -238,7 +240,7 @@ const BarOverlayContent = () => {
           </div>
         );
 
-        if (sec.stats && visibleItems.has('viewers')) sections.push(
+        if (sec.viewers && visibleItems.has('viewers')) sections.push(
           <div key="viewers" className="bar-section bar-stat-section">
             <div className="bar-stat-item">
               <div className="bar-stat-icon" aria-hidden="true">👥</div>
@@ -252,7 +254,7 @@ const BarOverlayContent = () => {
           </div>
         );
 
-        if (sec.stats && visibleItems.has('followers')) sections.push(
+        if (sec.followers && visibleItems.has('followers')) sections.push(
           <div key="followers" className="bar-section bar-stat-section">
             <div className="bar-stat-item">
               <div className="bar-stat-icon" aria-hidden="true">❤️</div>
@@ -264,7 +266,7 @@ const BarOverlayContent = () => {
           </div>
         );
 
-        if (sec.stats && visibleItems.has('subscribers')) sections.push(
+        if (sec.subscribers && visibleItems.has('subscribers')) sections.push(
           <div key="subscribers" className="bar-section bar-stat-section">
             <div className="bar-stat-item">
               <div className="bar-stat-icon" aria-hidden="true">⭐</div>

--- a/src/pages/overlay/BarOverlay.tsx
+++ b/src/pages/overlay/BarOverlay.tsx
@@ -126,15 +126,25 @@ const BarOverlayContent = () => {
   };
 
   const visibleItems = useMemo(() => {
-    type ItemKey = 'clock' | 'duration' | 'title' | 'stats' | 'recentFollower' | 'recentSub';
+    type ItemKey =
+      | 'clock'
+      | 'duration'
+      | 'title'
+      | 'viewers'
+      | 'followers'
+      | 'subscribers'
+      | 'recentFollower'
+      | 'recentSub';
 
     const config: Array<{ key: ItemKey; enabled: boolean; minWidth: number; dropRank: number; keep?: boolean }> = [
       { key: 'clock', enabled: settings.barSections.clock, minWidth: 114, dropRank: 3 },
       { key: 'duration', enabled: settings.barSections.duration, minWidth: 132, dropRank: 4 },
-      { key: 'title', enabled: settings.barSections.title, minWidth: 220, dropRank: 0, keep: true },
-      { key: 'stats', enabled: settings.barSections.stats, minWidth: 232, dropRank: 2 },
-      { key: 'recentFollower', enabled: settings.barSections.recentFollower && !!twitch.lastFollower, minWidth: 214, dropRank: 1 },
-      { key: 'recentSub', enabled: settings.barSections.recentSub && !!twitch.lastSubscriber, minWidth: 214, dropRank: 5 },
+      { key: 'title', enabled: settings.barSections.title, minWidth: 148, dropRank: 0, keep: true },
+      { key: 'viewers', enabled: settings.barSections.stats, minWidth: 92, dropRank: 2 },
+      { key: 'followers', enabled: settings.barSections.stats, minWidth: 92, dropRank: 5 },
+      { key: 'subscribers', enabled: settings.barSections.stats, minWidth: 102, dropRank: 6 },
+      { key: 'recentFollower', enabled: settings.barSections.recentFollower && !!twitch.lastFollower, minWidth: 144, dropRank: 1 },
+      { key: 'recentSub', enabled: settings.barSections.recentSub && !!twitch.lastSubscriber, minWidth: 144, dropRank: 7 },
     ];
 
     const active = config.filter((item) => item.enabled);
@@ -228,8 +238,8 @@ const BarOverlayContent = () => {
           </div>
         );
 
-        if (sec.stats && visibleItems.has('stats')) sections.push(
-          <div key="stats" className="bar-section bar-stats-section">
+        if (sec.stats && visibleItems.has('viewers')) sections.push(
+          <div key="viewers" className="bar-section bar-stat-section">
             <div className="bar-stat-item">
               <div className="bar-stat-icon" aria-hidden="true">👥</div>
               <div className="bar-stat-content">
@@ -239,11 +249,28 @@ const BarOverlayContent = () => {
                 <div className="bar-stat-label">Viewers</div>
               </div>
             </div>
+          </div>
+        );
+
+        if (sec.stats && visibleItems.has('followers')) sections.push(
+          <div key="followers" className="bar-section bar-stat-section">
             <div className="bar-stat-item">
               <div className="bar-stat-icon" aria-hidden="true">❤️</div>
               <div className="bar-stat-content">
                 <div className="bar-stat-value">{formatNumber(twitch.followerCount)}</div>
                 <div className="bar-stat-label">Followers</div>
+              </div>
+            </div>
+          </div>
+        );
+
+        if (sec.stats && visibleItems.has('subscribers')) sections.push(
+          <div key="subscribers" className="bar-section bar-stat-section">
+            <div className="bar-stat-item">
+              <div className="bar-stat-icon" aria-hidden="true">⭐</div>
+              <div className="bar-stat-content">
+                <div className="bar-stat-value">{formatNumber(twitch.subscriberCount)}</div>
+                <div className="bar-stat-label">Subscribers</div>
               </div>
             </div>
           </div>

--- a/src/pages/overlay/BarOverlay.tsx
+++ b/src/pages/overlay/BarOverlay.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useSettings } from '../../contexts/SettingsContext';
 import { TwitchProvider } from '../../contexts/TwitchContext';
 import ThemeBackground from '../../components/ThemeBackground';
@@ -11,7 +11,9 @@ const BarOverlayContent = () => {
   const { settings, isLoadingSettings } = useSettings();
   const twitch = TwitchProvider.useTwitch();
   const reducedEffects = settings.themeSettings.y2k.reducedEffects;
+  const overlayRef = useRef<HTMLDivElement>(null);
   const [currentTime, setCurrentTime] = useState(new Date());
+  const [overlayWidth, setOverlayWidth] = useState(0);
   const [newFollowerAnimation, setNewFollowerAnimation] = useState(false);
   const [newSubscriberAnimation, setNewSubscriberAnimation] = useState(false);
   const [prevFollower, setPrevFollower] = useState<string | null>(null);
@@ -30,6 +32,28 @@ const BarOverlayContent = () => {
   useEffect(() => {
     document.body.classList.add('overlay-mode');
     return () => document.body.classList.remove('overlay-mode');
+  }, []);
+
+  // Track rendered width so lower-priority items can be hidden as space shrinks.
+  useEffect(() => {
+    const measure = () => {
+      const nextWidth = overlayRef.current?.clientWidth ?? 0;
+      setOverlayWidth((prev) => (prev === nextWidth ? prev : nextWidth));
+    };
+
+    measure();
+
+    const node = overlayRef.current;
+    if (!node) return;
+
+    if (typeof ResizeObserver !== 'undefined') {
+      const ro = new ResizeObserver(measure);
+      ro.observe(node);
+      return () => ro.disconnect();
+    }
+
+    window.addEventListener('resize', measure);
+    return () => window.removeEventListener('resize', measure);
   }, []);
 
   // TwitchContext handles connection automatically - no manual connection needed
@@ -101,10 +125,62 @@ const BarOverlayContent = () => {
     return `${days}d ago`;
   };
 
+  const visibleItems = useMemo(() => {
+    type ItemKey = 'clock' | 'duration' | 'title' | 'stats' | 'recentFollower' | 'recentSub';
+
+    const config: Array<{ key: ItemKey; enabled: boolean; minWidth: number; dropRank: number; keep?: boolean }> = [
+      { key: 'clock', enabled: settings.barSections.clock, minWidth: 114, dropRank: 3 },
+      { key: 'duration', enabled: settings.barSections.duration, minWidth: 132, dropRank: 4 },
+      { key: 'title', enabled: settings.barSections.title, minWidth: 220, dropRank: 0, keep: true },
+      { key: 'stats', enabled: settings.barSections.stats, minWidth: 232, dropRank: 2 },
+      { key: 'recentFollower', enabled: settings.barSections.recentFollower && !!twitch.lastFollower, minWidth: 214, dropRank: 1 },
+      { key: 'recentSub', enabled: settings.barSections.recentSub && !!twitch.lastSubscriber, minWidth: 214, dropRank: 5 },
+    ];
+
+    const active = config.filter((item) => item.enabled);
+    if (active.length === 0) return new Set<ItemKey>();
+
+    // On first render before measurement, keep all enabled sections.
+    if (overlayWidth <= 0) return new Set<ItemKey>(active.map((item) => item.key));
+
+    // Reserve a little room for dividers and section gaps.
+    const dividerBudget = Math.max(0, active.length - 1) * 16;
+    const available = Math.max(0, overlayWidth - 24);
+    let total = active.reduce((sum, item) => sum + item.minWidth, 0) + dividerBudget;
+    const keep = new Set<ItemKey>(active.map((item) => item.key));
+
+    const droppable = [...active]
+      .filter((item) => !item.keep)
+      .sort((a, b) => b.dropRank - a.dropRank);
+
+    for (const item of droppable) {
+      if (total <= available) break;
+      if (!keep.has(item.key)) continue;
+      keep.delete(item.key);
+      total -= item.minWidth + 16;
+    }
+
+    // Always keep at least one item visible.
+    if (keep.size === 0 && active[0]) keep.add(active[0].key);
+
+    return keep;
+  }, [
+    overlayWidth,
+    settings.barSections.clock,
+    settings.barSections.duration,
+    settings.barSections.title,
+    settings.barSections.stats,
+    settings.barSections.recentFollower,
+    settings.barSections.recentSub,
+    twitch.lastFollower,
+    twitch.lastSubscriber,
+  ]);
+
   if (isLoadingSettings) return null;
 
   return (
     <div
+      ref={overlayRef}
       className={`bar-overlay${settings.theme === 'crt' ? ' crt-active' : ''}${!settings.barFloating ? ' full-width' : ''}${settings.theme === 'y2k' ? ' y2k-active' : ''}`}
       style={{ opacity: settings.perOverlayOpacity?.bar ?? settings.overlayOpacity, fontSize: `${settings.perOverlayFontSize?.bar ?? settings.fontSize}rem` }}
     >
@@ -121,8 +197,8 @@ const BarOverlayContent = () => {
         const sec = settings.barSections;
         const sections: React.ReactNode[] = [];
 
-        if (sec.clock) sections.push(
-          <div key="clock" className="bar-section">
+        if (sec.clock && visibleItems.has('clock')) sections.push(
+          <div key="clock" className="bar-section bar-section-clock">
             <div className="bar-stat-content">
               <div className="bar-time-value">{formatTime(currentTime)}</div>
               <div className="bar-time-label">Current Time</div>
@@ -130,8 +206,8 @@ const BarOverlayContent = () => {
           </div>
         );
 
-        if (sec.duration) sections.push(
-          <div key="duration" className="bar-section">
+        if (sec.duration && visibleItems.has('duration')) sections.push(
+          <div key="duration" className="bar-section bar-section-duration">
             <div className="bar-stat-content">
               <div className="bar-time-value">{formatStreamDuration()}</div>
               <div className="bar-time-label">Stream Duration</div>
@@ -139,7 +215,7 @@ const BarOverlayContent = () => {
           </div>
         );
 
-        if (sec.title) sections.push(
+        if (sec.title && visibleItems.has('title')) sections.push(
           <div key="title" className="bar-section bar-stream-section">
             <MarqueeText
               className="bar-stream-title"
@@ -152,7 +228,7 @@ const BarOverlayContent = () => {
           </div>
         );
 
-        if (sec.stats) sections.push(
+        if (sec.stats && visibleItems.has('stats')) sections.push(
           <div key="stats" className="bar-section bar-stats-section">
             <div className="bar-stat-item">
               <div className="bar-stat-icon" aria-hidden="true">👥</div>
@@ -173,10 +249,12 @@ const BarOverlayContent = () => {
           </div>
         );
 
-        const hasRecent = sec.recentFollower || sec.recentSub;
+        const showRecentFollower = sec.recentFollower && !!twitch.lastFollower && visibleItems.has('recentFollower');
+        const showRecentSub = sec.recentSub && !!twitch.lastSubscriber && visibleItems.has('recentSub');
+        const hasRecent = showRecentFollower || showRecentSub;
         if (hasRecent) sections.push(
           <div key="recent" className="bar-section bar-recent-section">
-            {sec.recentFollower && twitch.lastFollower && (
+            {showRecentFollower && twitch.lastFollower && (
               <div className={`bar-recent-item ${newFollowerAnimation ? 'new-update' : ''}`}>
                 <div className="bar-recent-icon" aria-hidden="true">❤️</div>
                 <div className="bar-recent-content">
@@ -185,7 +263,7 @@ const BarOverlayContent = () => {
                 </div>
               </div>
             )}
-            {sec.recentSub && twitch.lastSubscriber && (
+            {showRecentSub && twitch.lastSubscriber && (
               <div className={`bar-recent-item ${newSubscriberAnimation ? 'new-update' : ''}`}>
                 <div className="bar-recent-icon" aria-hidden="true">⭐</div>
                 <div className="bar-recent-content">

--- a/src/pages/overlay/BarOverlay.tsx
+++ b/src/pages/overlay/BarOverlay.tsx
@@ -36,6 +36,8 @@ const BarOverlayContent = () => {
 
   // Track rendered width so lower-priority items can be hidden as space shrinks.
   useEffect(() => {
+    if (isLoadingSettings) return;
+
     const measure = () => {
       const nextWidth = overlayRef.current?.clientWidth ?? 0;
       setOverlayWidth((prev) => (prev === nextWidth ? prev : nextWidth));
@@ -54,7 +56,7 @@ const BarOverlayContent = () => {
 
     window.addEventListener('resize', measure);
     return () => window.removeEventListener('resize', measure);
-  }, []);
+  }, [isLoadingSettings]);
 
   // TwitchContext handles connection automatically - no manual connection needed
 

--- a/src/pages/overlay/BarOverlay.tsx
+++ b/src/pages/overlay/BarOverlay.tsx
@@ -39,24 +39,34 @@ const BarOverlayContent = () => {
     if (isLoadingSettings) return;
 
     const measure = () => {
-      const nextWidth = overlayRef.current?.clientWidth ?? 0;
+      // In floating mode the bar shrinks to fit its content, so measuring the
+      // bar's own clientWidth creates a feedback loop (bar shrinks → less budget
+      // → more items hidden → bar shrinks further). Instead use the viewport
+      // width capped at 95 % as the available budget so items are shown/hidden
+      // based on the maximum space the bar could ever occupy.
+      const nextWidth = settings.barFloating
+        ? window.innerWidth * 0.95
+        : (overlayRef.current?.clientWidth ?? 0);
       setOverlayWidth((prev) => (prev === nextWidth ? prev : nextWidth));
     };
 
     measure();
 
-    const node = overlayRef.current;
-    if (!node) return;
-
-    if (typeof ResizeObserver !== 'undefined') {
-      const ro = new ResizeObserver(measure);
-      ro.observe(node);
-      return () => ro.disconnect();
+    // Full-width mode: observe the bar element (it fills 100 vw so the bar's
+    // clientWidth is the right budget and changes on window resize).
+    // Floating mode: just listen on window resize so the 95 vw budget updates.
+    if (!settings.barFloating) {
+      const node = overlayRef.current;
+      if (node && typeof ResizeObserver !== 'undefined') {
+        const ro = new ResizeObserver(measure);
+        ro.observe(node);
+        return () => ro.disconnect();
+      }
     }
 
     window.addEventListener('resize', measure);
     return () => window.removeEventListener('resize', measure);
-  }, [isLoadingSettings]);
+  }, [isLoadingSettings, settings.barFloating]);
 
   // TwitchContext handles connection automatically - no manual connection needed
 
@@ -178,6 +188,7 @@ const BarOverlayContent = () => {
     return keep;
   }, [
     overlayWidth,
+    settings.barFloating,
     settings.barSections.clock,
     settings.barSections.duration,
     settings.barSections.title,

--- a/src/pages/overlay/BarOverlay.tsx
+++ b/src/pages/overlay/BarOverlay.tsx
@@ -286,7 +286,10 @@ const BarOverlayContent = () => {
                 <div className="bar-recent-icon" aria-hidden="true">❤️</div>
                 <div className="bar-recent-content">
                   <MarqueeText className="bar-recent-name" text={twitch.lastFollower.userDisplayName} />
-                  <div className="bar-recent-label">Last Follow {formatRelativeTime(twitch.lastFollower.followDate)}</div>
+                  <MarqueeText
+                    className="bar-recent-label"
+                    text={`Last Follow ${formatRelativeTime(twitch.lastFollower.followDate)}`}
+                  />
                 </div>
               </div>
             )}
@@ -295,10 +298,10 @@ const BarOverlayContent = () => {
                 <div className="bar-recent-icon" aria-hidden="true">⭐</div>
                 <div className="bar-recent-content">
                   <MarqueeText className="bar-recent-name" text={twitch.lastSubscriber.userDisplayName} />
-                  <div className="bar-recent-label">
-                    Last Sub{twitch.lastSubscriber.subscribeDate ? ` ${formatRelativeTime(twitch.lastSubscriber.subscribeDate)}` : ''}
-                    {twitch.lastSubscriber.isGift && ' (Gift)'}
-                  </div>
+                  <MarqueeText
+                    className="bar-recent-label"
+                    text={`Last Sub${twitch.lastSubscriber.subscribeDate ? ` ${formatRelativeTime(twitch.lastSubscriber.subscribeDate)}` : ''}${twitch.lastSubscriber.isGift ? ' (Gift)' : ''}`}
+                  />
                 </div>
               </div>
             )}

--- a/src/server/settings.ts
+++ b/src/server/settings.ts
@@ -120,7 +120,7 @@ router.patch('/', express.json(), (req: Request, res: Response) => {
       errors.push('barSections must be an object');
     } else {
       const sections: Partial<OverlaySettings['barSections']> = {};
-      for (const key of ['clock', 'duration', 'title', 'stats', 'viewers', 'followers', 'subscribers', 'recentFollower', 'recentSub'] as const) {
+      for (const key of ['clock', 'duration', 'title', 'viewers', 'followers', 'subscribers', 'recentFollower', 'recentSub'] as const) {
         if (key in v) {
           const val = (v as unknown as Record<string, unknown>)[key];
           if (typeof val !== 'boolean') {

--- a/src/server/settings.ts
+++ b/src/server/settings.ts
@@ -9,6 +9,7 @@
 
 import express, { type Request, type Response, Router } from 'express';
 import { getUserTokens, updateUserSettings, defaultOverlaySettings, type OverlaySettings } from './storage.js';
+import { normalizeBarSections } from './shared/overlaySettings.js';
 
 const router: Router = express.Router();
 
@@ -25,7 +26,7 @@ router.get('/', (req: Request, res: Response) => {
     ...raw,
     perOverlayOpacity: { ...defaultOverlaySettings.perOverlayOpacity, ...(raw.perOverlayOpacity ?? {}) },
     perOverlayFontSize: { ...defaultOverlaySettings.perOverlayFontSize, ...(raw.perOverlayFontSize ?? {}) },
-    barSections: { ...defaultOverlaySettings.barSections, ...(raw.barSections ?? {}) },
+    barSections: normalizeBarSections(raw.barSections),
     themeSettings: {
       ...defaultOverlaySettings.themeSettings,
       ...(raw.themeSettings ?? {}),
@@ -116,7 +117,7 @@ router.patch('/', express.json(), (req: Request, res: Response) => {
       errors.push('barSections must be an object');
     } else {
       const sections: Partial<OverlaySettings['barSections']> = {};
-      for (const key of ['clock', 'duration', 'title', 'stats', 'recentFollower', 'recentSub'] as const) {
+      for (const key of ['clock', 'duration', 'title', 'stats', 'viewers', 'followers', 'subscribers', 'recentFollower', 'recentSub'] as const) {
         if (key in v) {
           const val = (v as unknown as Record<string, unknown>)[key];
           if (typeof val !== 'boolean') {
@@ -126,7 +127,7 @@ router.patch('/', express.json(), (req: Request, res: Response) => {
           }
         }
       }
-      if (errors.length === 0) patch.barSections = { ...defaultOverlaySettings.barSections, ...sections };
+      if (errors.length === 0) patch.barSections = normalizeBarSections(sections);
     }
   }
 

--- a/src/server/settings.ts
+++ b/src/server/settings.ts
@@ -12,6 +12,9 @@ import { getUserTokens, updateUserSettings, defaultOverlaySettings, type Overlay
 import { normalizeBarSections } from './shared/overlaySettings.js';
 
 const router: Router = express.Router();
+type OverlaySettingsPatch = Omit<Partial<OverlaySettings>, 'barSections'> & {
+  barSections?: Partial<OverlaySettings['barSections']>;
+};
 
 /**
  * GET /api/settings
@@ -48,13 +51,13 @@ router.get('/', (req: Request, res: Response) => {
  * Validates and merges the provided partial settings into the stored settings.
  */
 router.patch('/', express.json(), (req: Request, res: Response) => {
-  const body = req.body as Partial<OverlaySettings>;
+  const body = req.body as OverlaySettingsPatch;
   if (typeof body !== 'object' || body === null || Array.isArray(body)) {
     res.status(400).json({ error: 'Request body must be a JSON object' });
     return;
   }
 
-  const patch: Partial<OverlaySettings> = {};
+  const patch: OverlaySettingsPatch = {};
   const errors: string[] = [];
 
   if ('overlayOpacity' in body) {
@@ -127,7 +130,7 @@ router.patch('/', express.json(), (req: Request, res: Response) => {
           }
         }
       }
-      if (errors.length === 0) patch.barSections = normalizeBarSections(sections);
+      if (errors.length === 0) patch.barSections = sections;
     }
   }
 

--- a/src/server/shared/overlaySettings.ts
+++ b/src/server/shared/overlaySettings.ts
@@ -12,9 +12,46 @@ export interface BarSections {
   clock: boolean;
   duration: boolean;
   title: boolean;
+  /** Legacy aggregate toggle kept for backward compatibility with older saved settings. */
   stats: boolean;
+  viewers: boolean;
+  followers: boolean;
+  subscribers: boolean;
   recentFollower: boolean;
   recentSub: boolean;
+}
+
+const DEFAULT_BAR_SECTIONS: BarSections = {
+  clock: true,
+  duration: true,
+  title: true,
+  stats: true,
+  viewers: true,
+  followers: true,
+  subscribers: true,
+  recentFollower: true,
+  recentSub: true,
+};
+
+export function normalizeBarSections(raw?: Partial<BarSections> | null): BarSections {
+  const src = raw ?? {};
+  const legacyStats = typeof src.stats === 'boolean' ? src.stats : undefined;
+
+  const viewers = typeof src.viewers === 'boolean' ? src.viewers : (legacyStats ?? DEFAULT_BAR_SECTIONS.viewers);
+  const followers = typeof src.followers === 'boolean' ? src.followers : (legacyStats ?? DEFAULT_BAR_SECTIONS.followers);
+  const subscribers = typeof src.subscribers === 'boolean' ? src.subscribers : (legacyStats ?? DEFAULT_BAR_SECTIONS.subscribers);
+
+  return {
+    clock: typeof src.clock === 'boolean' ? src.clock : DEFAULT_BAR_SECTIONS.clock,
+    duration: typeof src.duration === 'boolean' ? src.duration : DEFAULT_BAR_SECTIONS.duration,
+    title: typeof src.title === 'boolean' ? src.title : DEFAULT_BAR_SECTIONS.title,
+    stats: typeof src.stats === 'boolean' ? src.stats : (viewers || followers || subscribers),
+    viewers,
+    followers,
+    subscribers,
+    recentFollower: typeof src.recentFollower === 'boolean' ? src.recentFollower : DEFAULT_BAR_SECTIONS.recentFollower,
+    recentSub: typeof src.recentSub === 'boolean' ? src.recentSub : DEFAULT_BAR_SECTIONS.recentSub,
+  };
 }
 
 export interface OverlaySettings {
@@ -53,14 +90,7 @@ export const defaultOverlaySettings: OverlaySettings = {
   chatFeedDirection: 'bottom',
   maxChatMessages: 50,
   barFloating: true,
-  barSections: {
-    clock: true,
-    duration: true,
-    title: true,
-    stats: true,
-    recentFollower: true,
-    recentSub: true,
-  },
+  barSections: { ...DEFAULT_BAR_SECTIONS },
   theme: 'crt',
   themeSettings: {
     crt: {

--- a/src/server/shared/overlaySettings.ts
+++ b/src/server/shared/overlaySettings.ts
@@ -12,8 +12,6 @@ export interface BarSections {
   clock: boolean;
   duration: boolean;
   title: boolean;
-  /** Legacy aggregate toggle kept for backward compatibility with older saved settings. */
-  stats: boolean;
   viewers: boolean;
   followers: boolean;
   subscribers: boolean;
@@ -25,7 +23,6 @@ const DEFAULT_BAR_SECTIONS: BarSections = {
   clock: true,
   duration: true,
   title: true,
-  stats: true,
   viewers: true,
   followers: true,
   subscribers: true,
@@ -35,20 +32,13 @@ const DEFAULT_BAR_SECTIONS: BarSections = {
 
 export function normalizeBarSections(raw?: Partial<BarSections> | null): BarSections {
   const src = raw ?? {};
-  const legacyStats = typeof src.stats === 'boolean' ? src.stats : undefined;
-
-  const viewers = typeof src.viewers === 'boolean' ? src.viewers : (legacyStats ?? DEFAULT_BAR_SECTIONS.viewers);
-  const followers = typeof src.followers === 'boolean' ? src.followers : (legacyStats ?? DEFAULT_BAR_SECTIONS.followers);
-  const subscribers = typeof src.subscribers === 'boolean' ? src.subscribers : (legacyStats ?? DEFAULT_BAR_SECTIONS.subscribers);
-
   return {
     clock: typeof src.clock === 'boolean' ? src.clock : DEFAULT_BAR_SECTIONS.clock,
     duration: typeof src.duration === 'boolean' ? src.duration : DEFAULT_BAR_SECTIONS.duration,
     title: typeof src.title === 'boolean' ? src.title : DEFAULT_BAR_SECTIONS.title,
-    stats: typeof src.stats === 'boolean' ? src.stats : (viewers || followers || subscribers),
-    viewers,
-    followers,
-    subscribers,
+    viewers: typeof src.viewers === 'boolean' ? src.viewers : DEFAULT_BAR_SECTIONS.viewers,
+    followers: typeof src.followers === 'boolean' ? src.followers : DEFAULT_BAR_SECTIONS.followers,
+    subscribers: typeof src.subscribers === 'boolean' ? src.subscribers : DEFAULT_BAR_SECTIONS.subscribers,
     recentFollower: typeof src.recentFollower === 'boolean' ? src.recentFollower : DEFAULT_BAR_SECTIONS.recentFollower,
     recentSub: typeof src.recentSub === 'boolean' ? src.recentSub : DEFAULT_BAR_SECTIONS.recentSub,
   };

--- a/src/server/storage.ts
+++ b/src/server/storage.ts
@@ -13,7 +13,7 @@ const __dirname = path.dirname(__filename);
 // in the Dockerfile so the path always matches the Docker volume mount point.
 const TOKENS_DIR = process.env.TOKENS_DIR ?? path.join(__dirname, '../../tokens');
 
-import { defaultOverlaySettings, normalizeBarSections, type BarSections, type OverlaySettings, type OverlayTheme, type PerOverlayNumber } from './shared/overlaySettings.js';
+import { defaultOverlaySettings, normalizeBarSections, type OverlaySettings, type OverlayTheme, type PerOverlayNumber } from './shared/overlaySettings.js';
 export type { OverlaySettings, OverlayTheme };
 export { defaultOverlaySettings };
 
@@ -256,18 +256,7 @@ export function updateUserSettings(username: string, settings: OverlaySettingsPa
       const patchBarSections = settings.barSections;
       if (!patchBarSections) return baseBarSections;
 
-      const nextBarSections: Partial<BarSections> = {
-        ...baseBarSections,
-        ...patchBarSections,
-      };
-
-      if ('stats' in patchBarSections) {
-        if (!('viewers' in patchBarSections)) nextBarSections.viewers = patchBarSections.stats;
-        if (!('followers' in patchBarSections)) nextBarSections.followers = patchBarSections.stats;
-        if (!('subscribers' in patchBarSections)) nextBarSections.subscribers = patchBarSections.stats;
-      }
-
-      return normalizeBarSections(nextBarSections);
+      return normalizeBarSections({ ...baseBarSections, ...patchBarSections });
     })();
 
     const merged: OverlaySettings = {

--- a/src/server/storage.ts
+++ b/src/server/storage.ts
@@ -13,9 +13,13 @@ const __dirname = path.dirname(__filename);
 // in the Dockerfile so the path always matches the Docker volume mount point.
 const TOKENS_DIR = process.env.TOKENS_DIR ?? path.join(__dirname, '../../tokens');
 
-import { defaultOverlaySettings, normalizeBarSections, type OverlaySettings, type OverlayTheme, type PerOverlayNumber } from './shared/overlaySettings.js';
+import { defaultOverlaySettings, normalizeBarSections, type BarSections, type OverlaySettings, type OverlayTheme, type PerOverlayNumber } from './shared/overlaySettings.js';
 export type { OverlaySettings, OverlayTheme };
 export { defaultOverlaySettings };
+
+type OverlaySettingsPatch = Omit<Partial<OverlaySettings>, 'barSections'> & {
+  barSections?: Partial<OverlaySettings['barSections']>;
+};
 
 // TokenData: the input shape — what the OAuth callback has available to pass into storeUserTokens().
 // All auth-critical fields are required; housekeeping fields (username, timestamps, settings) are
@@ -240,18 +244,37 @@ function mergePerOverlay(
  * Update overlay settings for a user identified by username.
  * Returns the fully-merged persisted settings on success, or null on failure.
  */
-export function updateUserSettings(username: string, settings: Partial<OverlaySettings>): OverlaySettings | null {
+export function updateUserSettings(username: string, settings: OverlaySettingsPatch): OverlaySettings | null {
   const tokenFile = path.join(TOKENS_DIR, `${username}.json`);
   if (!fs.existsSync(tokenFile)) return null;
 
   try {
     const data: StoredUserData = JSON.parse(fs.readFileSync(tokenFile, 'utf8'));
     const base = data.overlaySettings ?? defaultOverlaySettings;
+    const mergedBarSections = (() => {
+      const baseBarSections = normalizeBarSections(base.barSections);
+      const patchBarSections = settings.barSections;
+      if (!patchBarSections) return baseBarSections;
+
+      const nextBarSections: Partial<BarSections> = {
+        ...baseBarSections,
+        ...patchBarSections,
+      };
+
+      if ('stats' in patchBarSections) {
+        if (!('viewers' in patchBarSections)) nextBarSections.viewers = patchBarSections.stats;
+        if (!('followers' in patchBarSections)) nextBarSections.followers = patchBarSections.stats;
+        if (!('subscribers' in patchBarSections)) nextBarSections.subscribers = patchBarSections.stats;
+      }
+
+      return normalizeBarSections(nextBarSections);
+    })();
+
     const merged: OverlaySettings = {
       ...defaultOverlaySettings,
       ...base,
       ...settings,
-      barSections: normalizeBarSections(settings.barSections ?? base.barSections),
+      barSections: mergedBarSections,
       perOverlayOpacity: mergePerOverlay(defaultOverlaySettings.perOverlayOpacity, base.perOverlayOpacity ?? {}, settings.perOverlayOpacity),
       perOverlayFontSize: mergePerOverlay(defaultOverlaySettings.perOverlayFontSize, base.perOverlayFontSize ?? {}, settings.perOverlayFontSize),
       themeSettings: {

--- a/src/server/storage.ts
+++ b/src/server/storage.ts
@@ -13,7 +13,7 @@ const __dirname = path.dirname(__filename);
 // in the Dockerfile so the path always matches the Docker volume mount point.
 const TOKENS_DIR = process.env.TOKENS_DIR ?? path.join(__dirname, '../../tokens');
 
-import { defaultOverlaySettings, type OverlaySettings, type OverlayTheme, type PerOverlayNumber } from './shared/overlaySettings.js';
+import { defaultOverlaySettings, normalizeBarSections, type OverlaySettings, type OverlayTheme, type PerOverlayNumber } from './shared/overlaySettings.js';
 export type { OverlaySettings, OverlayTheme };
 export { defaultOverlaySettings };
 
@@ -99,6 +99,7 @@ export function storeUserTokens(username: string, tokenData: TokenData): void {
     overlaySettings: {
       ...defaultOverlaySettings,
       ...(existingData?.overlaySettings ?? {}),
+      barSections: normalizeBarSections(existingData?.overlaySettings?.barSections),
       perOverlayOpacity: {
         ...defaultOverlaySettings.perOverlayOpacity,
         ...(existingData?.overlaySettings?.perOverlayOpacity ?? {}),
@@ -250,6 +251,7 @@ export function updateUserSettings(username: string, settings: Partial<OverlaySe
       ...defaultOverlaySettings,
       ...base,
       ...settings,
+      barSections: normalizeBarSections(settings.barSections ?? base.barSections),
       perOverlayOpacity: mergePerOverlay(defaultOverlaySettings.perOverlayOpacity, base.perOverlayOpacity ?? {}, settings.perOverlayOpacity),
       perOverlayFontSize: mergePerOverlay(defaultOverlaySettings.perOverlayFontSize, base.perOverlayFontSize ?? {}, settings.perOverlayFontSize),
       themeSettings: {

--- a/src/styles/BarOverlay.css
+++ b/src/styles/BarOverlay.css
@@ -117,14 +117,14 @@
 }
 
 .bar-overlay.crt-active .bar-stat-item {
-  background: rgba(var(--MainRGBA), 0.1);
-  border: 1px solid rgba(var(--MainRGBA), 0.3);
+  background: transparent;
+  border: none;
 }
 
 .bar-overlay.crt-active .bar-stat-item:hover {
-  background: rgba(var(--MainRGBA), 0.2);
-  border-color: var(--Main);
-  transform: translateY(-1px);
+  background: transparent;
+  border: none;
+  transform: none;
 }
 
 .bar-stat-icon {

--- a/src/styles/BarOverlay.css
+++ b/src/styles/BarOverlay.css
@@ -187,6 +187,11 @@
   max-width: 240px;
 }
 
+.bar-overlay.full-width .bar-recent-section {
+  flex: 1 1 360px;
+  max-width: 360px;
+}
+
 .bar-recent-item {
   display: flex;
   align-items: center;

--- a/src/styles/BarOverlay.css
+++ b/src/styles/BarOverlay.css
@@ -8,7 +8,7 @@
   display: flex;
   align-items: center;
   gap: 0.9rem;
-  min-width: 600px;
+  width: max-content;
   max-width: 95vw;
   z-index: 1000;
   height: 60px;
@@ -158,8 +158,13 @@
   display: flex;
   flex-direction: column;
   gap: 0.1rem;
+  flex: 0 0 auto;
+  min-width: 148px;
+  max-width: 320px;
+}
+
+.bar-overlay.full-width .bar-stream-section {
   flex: 1 1 148px;
-  min-width: 0;
   max-width: none;
 }
 

--- a/src/styles/BarOverlay.css
+++ b/src/styles/BarOverlay.css
@@ -119,6 +119,8 @@
 .bar-overlay.crt-active .bar-stat-item {
   background: transparent;
   border: none;
+  border-radius: 0;
+  padding: 0;
 }
 
 .bar-overlay.crt-active .bar-stat-item:hover {

--- a/src/styles/BarOverlay.css
+++ b/src/styles/BarOverlay.css
@@ -7,12 +7,14 @@
   pointer-events: none;
   display: flex;
   align-items: center;
-  gap: 1.5rem;
+  gap: 0.9rem;
   min-width: 600px;
   max-width: 95vw;
   z-index: 1000;
   height: 60px;
   isolation: isolate;
+  flex-wrap: nowrap;
+  overflow: hidden;
 }
 
 .bar-overlay.full-width {
@@ -28,8 +30,8 @@
   border-right: none;
   border-bottom: none;
   box-shadow: none;
-  justify-content: space-between;
-  gap: 1rem;
+  justify-content: flex-start;
+  gap: 0.9rem;
   padding: 0 1.5rem;
 }
 
@@ -56,6 +58,13 @@
   display: flex;
   align-items: center;
   gap: 0.75rem;
+  min-width: 0;
+  flex: 0 0 auto;
+}
+
+.bar-section-clock,
+.bar-section-duration {
+  flex: 0 0 auto;
 }
 
 .bar-time-label {
@@ -94,7 +103,8 @@
 .bar-stats-section {
   display: flex;
   align-items: center;
-  gap: 1.25rem;
+  gap: 0.65rem;
+  flex: 0 0 auto;
 }
 
 .bar-stat-item {
@@ -146,9 +156,9 @@
   display: flex;
   flex-direction: column;
   gap: 0.1rem;
-  flex: 1;
+  flex: 1 1 220px;
   min-width: 0;
-  max-width: 300px;
+  max-width: none;
 }
 
 .bar-stream-title {
@@ -169,9 +179,10 @@
 .bar-recent-section {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  flex: 1 1 260px;
+  gap: 0.6rem;
+  flex: 0 1 360px;
   min-width: 0;
+  max-width: 360px;
 }
 
 .bar-recent-item {
@@ -180,8 +191,8 @@
   gap: 0.5rem;
   padding: 0.4rem 1rem;
   min-width: 0;
-  max-width: clamp(180px, 24vw, 320px);
-  flex: 1 1 220px;
+  max-width: 100%;
+  flex: 1 1 0;
   transition: all 0.3s ease;
 }
 
@@ -370,10 +381,9 @@
 @media (max-width: 768px) {
   .bar-overlay {
     min-width: 90vw;
-    padding: 0.4rem 1rem;
-    gap: 0.75rem;
-    flex-wrap: wrap;
-    justify-content: center;
+    padding: 0.35rem 0.7rem;
+    gap: 0.55rem;
+    justify-content: flex-start;
     height: auto;
     min-height: 50px;
   }
@@ -384,16 +394,16 @@
   }
 
   .bar-stats-section {
-    gap: 0.75rem;
-  }
-
-  .bar-recent-section {
     gap: 0.5rem;
   }
 
+  .bar-recent-section {
+    gap: 0.45rem;
+    max-width: 260px;
+  }
+
   .bar-recent-item {
-    max-width: none;
-    flex: 1 1 140px;
+    flex: 1 1 0;
   }
 
   .bar-recent-name {
@@ -401,6 +411,6 @@
   }
 
   .bar-stream-section {
-    max-width: 200px;
+    flex: 1 1 160px;
   }
 }

--- a/src/styles/BarOverlay.css
+++ b/src/styles/BarOverlay.css
@@ -170,6 +170,8 @@
   display: flex;
   align-items: center;
   gap: 1rem;
+  flex: 1 1 260px;
+  min-width: 0;
 }
 
 .bar-recent-item {
@@ -177,7 +179,9 @@
   align-items: center;
   gap: 0.5rem;
   padding: 0.4rem 1rem;
-  min-width: 120px;
+  min-width: 0;
+  max-width: clamp(180px, 24vw, 320px);
+  flex: 1 1 220px;
   transition: all 0.3s ease;
 }
 
@@ -205,14 +209,16 @@
   flex-direction: column;
   gap: 0.05rem;
   flex: 1;
+  min-width: 0;
 }
 
 .bar-recent-name {
   color: #fff;
   font-size: 0.75em;
   font-weight: 600;
-  max-width: 90px;
-  flex: 0 1 auto;
+  max-width: 100%;
+  width: 100%;
+  flex: 1 1 auto;
 }
 
 .bar-recent-label {
@@ -282,7 +288,7 @@
 .bar-overlay.crt-active .bar-stat-label { color: rgba(var(--LightRGBA), 0.7); }
 .bar-overlay.crt-active .bar-stream-title { color: var(--Light); }
 .bar-overlay.crt-active .bar-stream-category { color: rgba(var(--LightRGBA), 0.7); }
-.bar-overlay.crt-active .bar-recent-item { background: rgba(var(--LightRGBA), 0.05); border: 1px solid rgba(var(--MainRGBA), 0.2); border-radius: 6px; }
+.bar-overlay.crt-active .bar-recent-item { background: transparent; border: 1px solid rgba(var(--MainRGBA), 0.22); border-radius: 6px; }
 .bar-overlay.crt-active .bar-recent-item.new-update { animation: pulseGlow 2s ease-in-out; border-color: var(--Main); background: rgba(var(--MainRGBA), 0.15); }
 .bar-overlay.crt-active .bar-recent-name { color: var(--Light); }
 .bar-overlay.crt-active .bar-recent-label { color: rgba(var(--LightRGBA), 0.6); }
@@ -386,11 +392,12 @@
   }
 
   .bar-recent-item {
-    min-width: 100px;
+    max-width: none;
+    flex: 1 1 140px;
   }
 
   .bar-recent-name {
-    max-width: 70px;
+    max-width: 100%;
   }
 
   .bar-stream-section {

--- a/src/styles/BarOverlay.css
+++ b/src/styles/BarOverlay.css
@@ -100,7 +100,7 @@
   opacity: 0.6;
 }
 
-.bar-stats-section {
+.bar-stat-section {
   display: flex;
   align-items: center;
   gap: 0.65rem;
@@ -156,7 +156,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.1rem;
-  flex: 1 1 220px;
+  flex: 1 1 148px;
   min-width: 0;
   max-width: none;
 }
@@ -180,9 +180,9 @@
   display: flex;
   align-items: center;
   gap: 0.6rem;
-  flex: 0 1 360px;
+  flex: 0 1 240px;
   min-width: 0;
-  max-width: 360px;
+  max-width: 240px;
 }
 
 .bar-recent-item {
@@ -393,13 +393,13 @@
     padding: 0.4rem 0.5rem;
   }
 
-  .bar-stats-section {
+  .bar-stat-section {
     gap: 0.5rem;
   }
 
   .bar-recent-section {
     gap: 0.45rem;
-    max-width: 260px;
+    max-width: 160px;
   }
 
   .bar-recent-item {
@@ -411,6 +411,6 @@
   }
 
   .bar-stream-section {
-    flex: 1 1 160px;
+    flex: 1 1 110px;
   }
 }

--- a/src/styles/BarOverlay.css
+++ b/src/styles/BarOverlay.css
@@ -237,6 +237,9 @@
   font-size: 0.6em;
   text-transform: uppercase;
   letter-spacing: 0.3px;
+  width: 100%;
+  white-space: nowrap;
+  line-height: 1.1;
 }
 
 /* CRT Effects specific to bar overlay */


### PR DESCRIPTION
## Summary
- remove the unintended bright rectangle background behind recent follow/sub text in CRT mode
- widen the recent-item layout lane so marquee text has more room before scrolling/cutoff
- keep the new-update pulse highlight behavior unchanged

## Details
- Updated `bar-recent-section` and `bar-recent-item` flex sizing to better use available space.
- Updated `bar-recent-content`/`bar-recent-name` sizing constraints to allow full-width marquee container usage.
- Changed CRT baseline style for recent items from filled background to transparent with subtle border.

## Why
This fixes two UI issues:
1. The bright block behind the recent-follow text looked like an accidental highlight.
2. The recent-follow marquee area was too narrow despite available bar space.
