### PR TITLE
Fix chat bottom-feed alignment and move header for bottom mode

### DIFF
--- a/src/pages/overlay/ChatOverlay.tsx
+++ b/src/pages/overlay/ChatOverlay.tsx
@@ -29,8 +29,8 @@ const ChatOverlay = () => {
 
   const header = (
     <div className="chat-header">
-      {isY2KTheme && isFeedFromTop && (
-        <div className="chat-y2k-divider chat-y2k-divider--top">
+      {isY2KTheme && !isFeedFromTop && (
+        <div className="chat-y2k-divider chat-y2k-divider--flipped">
           <Y2KDivider staticMode={reducedEffects} />
         </div>
       )}
@@ -41,7 +41,7 @@ const ChatOverlay = () => {
         {isConnected && settings.theme === 'crt' && <span className="connection-status connected"> (Live)</span>}
       </h3>
       {isY2KTheme ? (
-        !isFeedFromTop && (
+        isFeedFromTop && (
           <div className="chat-y2k-divider">
             <Y2KDivider staticMode={reducedEffects} />
           </div>

--- a/src/pages/overlay/ChatOverlay.tsx
+++ b/src/pages/overlay/ChatOverlay.tsx
@@ -13,7 +13,6 @@ const ChatOverlay = () => {
   const { messages, isConnected, isConnecting, error } = TwitchProvider.useTwitch();
   const reducedEffects = settings.themeSettings.y2k.reducedEffects;
   const isFeedFromTop = settings.chatFeedDirection === 'top';
-  const isY2KTheme = settings.theme === 'y2k';
 
   const messagesRef = useRef<HTMLDivElement>(null);
 
@@ -29,7 +28,7 @@ const ChatOverlay = () => {
 
   // Divider always separates title and chat content
   let divider: React.ReactNode = null;
-  if (isY2KTheme) {
+  if (settings.theme === 'y2k') {
     divider = (
       <div className={`chat-y2k-divider${!isFeedFromTop ? ' chat-y2k-divider--flipped' : ''}`}>
         <Y2KDivider staticMode={reducedEffects} />

--- a/src/pages/overlay/ChatOverlay.tsx
+++ b/src/pages/overlay/ChatOverlay.tsx
@@ -38,15 +38,19 @@ const ChatOverlay = () => {
     divider = <div className="chat-divider"></div>;
   }
 
+  // Y2K bottom-feed: divider above title (ornament closest to content); all other cases: divider below title
+  const dividerAboveTitle = settings.theme === 'y2k' && !isFeedFromTop;
+
   const headerBlock = (
     <div className="chat-header">
+      {dividerAboveTitle && divider}
       <h3>
         <span className="chat-icon" aria-hidden="true">💬</span> Stream Chat
         {isConnecting && <span className="connection-status connecting"> (Connecting...)</span>}
         {error && <span className="connection-status error" title={error}> (Connection Error)</span>}
         {isConnected && settings.theme === 'crt' && <span className="connection-status connected"> (Live)</span>}
       </h3>
-      {divider}
+      {!dividerAboveTitle && divider}
     </div>
   );
 

--- a/src/pages/overlay/ChatOverlay.tsx
+++ b/src/pages/overlay/ChatOverlay.tsx
@@ -12,6 +12,7 @@ const ChatOverlay = () => {
   const { settings, isLoadingSettings } = useSettings();
   const { messages, isConnected, isConnecting, error } = TwitchProvider.useTwitch();
   const reducedEffects = settings.themeSettings.y2k.reducedEffects;
+  const isFeedFromTop = settings.chatFeedDirection === 'top';
 
   const messagesRef = useRef<HTMLDivElement>(null);
 
@@ -25,23 +26,27 @@ const ChatOverlay = () => {
 
   if (isLoadingSettings) return null;
 
+  const header = (
+    <div className="chat-header">
+      <h3>
+        <span className="chat-icon" aria-hidden="true">💬</span> Stream Chat
+        {isConnecting && <span className="connection-status connecting"> (Connecting...)</span>}
+        {error && <span className="connection-status error" title={error}> (Connection Error)</span>}
+        {isConnected && settings.theme === 'crt' && <span className="connection-status connected"> (Live)</span>}
+      </h3>
+      {settings.theme === 'y2k' ? <Y2KDivider staticMode={reducedEffects} /> : <div className="chat-divider"></div>}
+    </div>
+  );
+
   return (
     <div
-      className={`chat-overlay${settings.theme === 'crt' ? ' crt-active' : ''}${settings.theme === 'y2k' ? ' y2k-active' : ''}`}
+      className={`chat-overlay${settings.theme === 'crt' ? ' crt-active' : ''}${settings.theme === 'y2k' ? ' y2k-active' : ''}${isFeedFromTop ? ' feed-from-top' : ' feed-from-bottom'}`}
       style={{ opacity: settings.perOverlayOpacity?.chat ?? settings.overlayOpacity, fontSize: `${settings.perOverlayFontSize?.chat ?? settings.fontSize}rem` }}
     >
       <ThemeBackground panelMode />
-      <div className="chat-header">
-        <h3>
-          <span className="chat-icon" aria-hidden="true">💬</span> Stream Chat
-          {isConnecting && <span className="connection-status connecting"> (Connecting...)</span>}
-          {error && <span className="connection-status error" title={error}> (Connection Error)</span>}
-          {isConnected && settings.theme === 'crt' && <span className="connection-status connected"> (Live)</span>}
-        </h3>
-        {settings.theme === 'y2k' ? <Y2KDivider staticMode={reducedEffects} /> : <div className="chat-divider"></div>}
-      </div>
+      {isFeedFromTop && header}
       
-      <div ref={messagesRef} className={`chat-messages ${settings.chatFeedDirection === 'top' ? 'feed-from-top' : 'feed-from-bottom'}`}>
+      <div ref={messagesRef} className={`chat-messages ${isFeedFromTop ? 'feed-from-top' : 'feed-from-bottom'}`}>
         <AnimatePresence mode="popLayout">
           {messages.map((msg) => (
             <motion.div
@@ -88,6 +93,7 @@ const ChatOverlay = () => {
           ))}
         </AnimatePresence>
       </div>
+      {!isFeedFromTop && header}
       <GlobalAlertLayer />
     </div>
   );

--- a/src/pages/overlay/ChatOverlay.tsx
+++ b/src/pages/overlay/ChatOverlay.tsx
@@ -38,8 +38,9 @@ const ChatOverlay = () => {
     divider = <div className="chat-divider"></div>;
   }
 
-  // Y2K bottom-feed: divider above title (ornament closest to content); all other cases: divider below title
-  const dividerAboveTitle = settings.theme === 'y2k' && !isFeedFromTop;
+  // Keep divider between content and title for all themes:
+  // top-feed: title -> divider -> content, bottom-feed: content -> divider -> title.
+  const dividerAboveTitle = !isFeedFromTop;
 
   const headerBlock = (
     <div className="chat-header">

--- a/src/pages/overlay/ChatOverlay.tsx
+++ b/src/pages/overlay/ChatOverlay.tsx
@@ -27,22 +27,29 @@ const ChatOverlay = () => {
 
   if (isLoadingSettings) return null;
 
+  // Determine divider placement and type
+  let divider: React.ReactNode = null;
+  if (isY2KTheme) {
+    divider = (
+      <div className={`chat-y2k-divider${!isFeedFromTop ? ' chat-y2k-divider--flipped' : ''}`}>
+        <Y2KDivider staticMode={reducedEffects} />
+      </div>
+    );
+  } else if (settings.theme === 'crt' || settings.theme === 'default') {
+    divider = <div className="chat-divider"></div>;
+  }
+
+  // For CRT and Y2K, divider is always above title. For default, above in bottom-feed, below in top-feed.
   const header = (
     <div className="chat-header">
-      {/* Divider always first, CSS controls order/flip */}
-      {isY2KTheme ? (
-        <div className="chat-divider chat-y2k-divider">
-          <Y2KDivider staticMode={reducedEffects} />
-        </div>
-      ) : (
-        <div className="chat-divider"></div>
-      )}
+      {(!isFeedFromTop || settings.theme === 'crt' || isY2KTheme) && divider}
       <h3>
         <span className="chat-icon" aria-hidden="true">💬</span> Stream Chat
         {isConnecting && <span className="connection-status connecting"> (Connecting...)</span>}
         {error && <span className="connection-status error" title={error}> (Connection Error)</span>}
         {isConnected && settings.theme === 'crt' && <span className="connection-status connected"> (Live)</span>}
       </h3>
+      {isFeedFromTop && settings.theme === 'default' && divider}
     </div>
   );
 

--- a/src/pages/overlay/ChatOverlay.tsx
+++ b/src/pages/overlay/ChatOverlay.tsx
@@ -27,7 +27,7 @@ const ChatOverlay = () => {
 
   if (isLoadingSettings) return null;
 
-  // Determine divider placement and type
+  // Divider always separates title and chat content
   let divider: React.ReactNode = null;
   if (isY2KTheme) {
     divider = (
@@ -35,21 +35,19 @@ const ChatOverlay = () => {
         <Y2KDivider staticMode={reducedEffects} />
       </div>
     );
-  } else if (settings.theme === 'crt' || settings.theme === 'default') {
+  } else {
     divider = <div className="chat-divider"></div>;
   }
 
-  // For CRT and Y2K, divider is always above title. For default, above in bottom-feed, below in top-feed.
-  const header = (
+  const headerBlock = (
     <div className="chat-header">
-      {(!isFeedFromTop || settings.theme === 'crt' || isY2KTheme) && divider}
       <h3>
         <span className="chat-icon" aria-hidden="true">💬</span> Stream Chat
         {isConnecting && <span className="connection-status connecting"> (Connecting...)</span>}
         {error && <span className="connection-status error" title={error}> (Connection Error)</span>}
         {isConnected && settings.theme === 'crt' && <span className="connection-status connected"> (Live)</span>}
       </h3>
-      {isFeedFromTop && settings.theme === 'default' && divider}
+      {divider}
     </div>
   );
 
@@ -59,8 +57,7 @@ const ChatOverlay = () => {
       style={{ opacity: settings.perOverlayOpacity?.chat ?? settings.overlayOpacity, fontSize: `${settings.perOverlayFontSize?.chat ?? settings.fontSize}rem` }}
     >
       <ThemeBackground panelMode />
-      {isFeedFromTop && header}
-      
+      {isFeedFromTop && headerBlock}
       <div ref={messagesRef} className={`chat-messages ${isFeedFromTop ? 'feed-from-top' : 'feed-from-bottom'}`}>
         <AnimatePresence mode="popLayout">
           {messages.map((msg) => (
@@ -108,7 +105,7 @@ const ChatOverlay = () => {
           ))}
         </AnimatePresence>
       </div>
-      {!isFeedFromTop && header}
+      {!isFeedFromTop && headerBlock}
       <GlobalAlertLayer />
     </div>
   );

--- a/src/pages/overlay/ChatOverlay.tsx
+++ b/src/pages/overlay/ChatOverlay.tsx
@@ -29,10 +29,13 @@ const ChatOverlay = () => {
 
   const header = (
     <div className="chat-header">
-      {isY2KTheme && !isFeedFromTop && (
-        <div className="chat-y2k-divider chat-y2k-divider--flipped">
+      {/* Divider always first, CSS controls order/flip */}
+      {isY2KTheme ? (
+        <div className="chat-divider chat-y2k-divider">
           <Y2KDivider staticMode={reducedEffects} />
         </div>
+      ) : (
+        <div className="chat-divider"></div>
       )}
       <h3>
         <span className="chat-icon" aria-hidden="true">💬</span> Stream Chat
@@ -40,15 +43,6 @@ const ChatOverlay = () => {
         {error && <span className="connection-status error" title={error}> (Connection Error)</span>}
         {isConnected && settings.theme === 'crt' && <span className="connection-status connected"> (Live)</span>}
       </h3>
-      {isY2KTheme ? (
-        isFeedFromTop && (
-          <div className="chat-y2k-divider">
-            <Y2KDivider staticMode={reducedEffects} />
-          </div>
-        )
-      ) : (
-        <div className="chat-divider"></div>
-      )}
     </div>
   );
 

--- a/src/pages/overlay/ChatOverlay.tsx
+++ b/src/pages/overlay/ChatOverlay.tsx
@@ -13,6 +13,7 @@ const ChatOverlay = () => {
   const { messages, isConnected, isConnecting, error } = TwitchProvider.useTwitch();
   const reducedEffects = settings.themeSettings.y2k.reducedEffects;
   const isFeedFromTop = settings.chatFeedDirection === 'top';
+  const isY2KTheme = settings.theme === 'y2k';
 
   const messagesRef = useRef<HTMLDivElement>(null);
 
@@ -28,13 +29,26 @@ const ChatOverlay = () => {
 
   const header = (
     <div className="chat-header">
+      {isY2KTheme && isFeedFromTop && (
+        <div className="chat-y2k-divider chat-y2k-divider--top">
+          <Y2KDivider staticMode={reducedEffects} />
+        </div>
+      )}
       <h3>
         <span className="chat-icon" aria-hidden="true">💬</span> Stream Chat
         {isConnecting && <span className="connection-status connecting"> (Connecting...)</span>}
         {error && <span className="connection-status error" title={error}> (Connection Error)</span>}
         {isConnected && settings.theme === 'crt' && <span className="connection-status connected"> (Live)</span>}
       </h3>
-      {settings.theme === 'y2k' ? <Y2KDivider staticMode={reducedEffects} /> : <div className="chat-divider"></div>}
+      {isY2KTheme ? (
+        !isFeedFromTop && (
+          <div className="chat-y2k-divider">
+            <Y2KDivider staticMode={reducedEffects} />
+          </div>
+        )
+      ) : (
+        <div className="chat-divider"></div>
+      )}
     </div>
   );
 

--- a/src/styles/ChatOverlay.css
+++ b/src/styles/ChatOverlay.css
@@ -85,6 +85,15 @@
   background: linear-gradient(90deg, transparent, var(--Main), transparent);
 }
 
+.chat-overlay.crt-active.feed-from-bottom .chat-header {
+  display: flex;
+  flex-direction: column-reverse;
+}
+
+.chat-overlay.crt-active.feed-from-bottom .chat-header h3 {
+  margin: 1rem 0 0 0;
+}
+
 .connection-status {
   font-size: 0.8em;
   font-weight: normal;

--- a/src/styles/ChatOverlay.css
+++ b/src/styles/ChatOverlay.css
@@ -61,6 +61,7 @@
 }
 
 .chat-overlay.crt-active .chat-header h3 {
+  margin: 1rem 0;
   color: var(--Main);
   text-shadow: 0 0 10px rgba(var(--MainRGBA), 0.5);
 }

--- a/src/styles/ChatOverlay.css
+++ b/src/styles/ChatOverlay.css
@@ -76,7 +76,7 @@
   width: 100%;
 }
 
-.chat-y2k-divider--top {
+.chat-y2k-divider--flipped {
   transform: scaleY(-1);
   transform-origin: center;
 }

--- a/src/styles/ChatOverlay.css
+++ b/src/styles/ChatOverlay.css
@@ -72,34 +72,14 @@
   border-radius: 1px;
 }
 
-
-.chat-divider {
-  width: 100%;
-}
-
 /* Y2K: flip divider vertically in feed-from-bottom */
 .chat-y2k-divider--flipped {
   transform: scaleY(-1);
   transform-origin: center;
 }
 
-/* CRT: add spacing when divider is above title */
-.chat-overlay.crt-active.feed-from-bottom .chat-header h3,
-.chat-overlay.crt-active.feed-from-top .chat-header h3 {
-  margin: 1rem 0 0 0;
-}
-
 .chat-overlay.crt-active .chat-divider {
   background: linear-gradient(90deg, transparent, var(--Main), transparent);
-}
-
-.chat-overlay.crt-active.feed-from-bottom .chat-header {
-  display: flex;
-  flex-direction: column-reverse;
-}
-
-.chat-overlay.crt-active.feed-from-bottom .chat-header h3 {
-  margin: 1rem 0 0 0;
 }
 
 .connection-status {

--- a/src/styles/ChatOverlay.css
+++ b/src/styles/ChatOverlay.css
@@ -13,14 +13,6 @@
   isolation: isolate;
 }
 
-.chat-overlay.feed-from-bottom .chat-messages {
-  order: 1;
-}
-
-.chat-overlay.feed-from-bottom .chat-header {
-  order: 2;
-}
-
 .chat-overlay.preview-mode {
   position: static;
   width: 350px;
@@ -78,6 +70,15 @@
   height: 1px;
   background: rgba(255,255,255,0.15);
   border-radius: 1px;
+}
+
+.chat-y2k-divider {
+  width: 100%;
+}
+
+.chat-y2k-divider--top {
+  transform: scaleY(-1);
+  transform-origin: center;
 }
 
 .chat-overlay.crt-active .chat-divider {

--- a/src/styles/ChatOverlay.css
+++ b/src/styles/ChatOverlay.css
@@ -72,13 +72,31 @@
   border-radius: 1px;
 }
 
-.chat-y2k-divider {
+
+.chat-divider {
   width: 100%;
 }
 
-.chat-y2k-divider--flipped {
+/* Default: divider above title */
+.chat-header {
+  display: flex;
+  flex-direction: column;
+}
+
+/* For feed-from-bottom, flip order so divider is above title for all themes */
+.feed-from-bottom .chat-header {
+  flex-direction: column-reverse;
+}
+
+/* Y2K: flip divider vertically in feed-from-bottom */
+.feed-from-bottom .chat-y2k-divider {
   transform: scaleY(-1);
   transform-origin: center;
+}
+
+/* CRT: add spacing when divider is above title */
+.chat-overlay.crt-active.feed-from-bottom .chat-header h3 {
+  margin: 1rem 0 0 0;
 }
 
 .chat-overlay.crt-active .chat-divider {

--- a/src/styles/ChatOverlay.css
+++ b/src/styles/ChatOverlay.css
@@ -77,25 +77,15 @@
   width: 100%;
 }
 
-/* Default: divider above title */
-.chat-header {
-  display: flex;
-  flex-direction: column;
-}
-
-/* For feed-from-bottom, flip order so divider is above title for all themes */
-.feed-from-bottom .chat-header {
-  flex-direction: column-reverse;
-}
-
 /* Y2K: flip divider vertically in feed-from-bottom */
-.feed-from-bottom .chat-y2k-divider {
+.chat-y2k-divider--flipped {
   transform: scaleY(-1);
   transform-origin: center;
 }
 
 /* CRT: add spacing when divider is above title */
-.chat-overlay.crt-active.feed-from-bottom .chat-header h3 {
+.chat-overlay.crt-active.feed-from-bottom .chat-header h3,
+.chat-overlay.crt-active.feed-from-top .chat-header h3 {
   margin: 1rem 0 0 0;
 }
 

--- a/src/styles/ChatOverlay.css
+++ b/src/styles/ChatOverlay.css
@@ -13,6 +13,14 @@
   isolation: isolate;
 }
 
+.chat-overlay.feed-from-bottom .chat-messages {
+  order: 1;
+}
+
+.chat-overlay.feed-from-bottom .chat-header {
+  order: 2;
+}
+
 .chat-overlay.preview-mode {
   position: static;
   width: 350px;
@@ -141,7 +149,9 @@
    feed-from-top:    newest at top (column-reverse), oldest overflow bottom → fade bottom edge. */
 .chat-messages.feed-from-bottom {
   flex-direction: column;
-  justify-content: flex-start;
+  justify-content: flex-end;
+  padding-top: 1rem;
+  padding-bottom: 0;
   -webkit-mask-image: linear-gradient(to bottom, transparent 10%, black 40%);
   mask-image: linear-gradient(to bottom, transparent 10%, black 40%);
 }
@@ -182,6 +192,11 @@
 
 .chat-overlay.y2k-active .chat-header {
   margin-top: 10vh;
+}
+
+.chat-overlay.y2k-active.feed-from-bottom .chat-header {
+  margin-top: 0;
+  margin-bottom: 10vh;
 }
 
 .chat-overlay.y2k-active .chat-messages {


### PR DESCRIPTION
## Summary
- fix bottom-feed chat alignment so short message lists anchor to the bottom instead of top
- remove the visible gap between the newest message and the bottom edge in bottom-feed mode
- render the chat header at the bottom when feed direction is bottom (and keep it at top for top-feed)
- adjust Y2K header spacing for bottom-feed mode

## Notes
- base branch is `docker-migration` as requested for temporary main/staging flow
- no runtime behavior changes outside chat feed-direction layout
