### PR TITLE
feat: add standalone border overlay with y2k star frame

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import ClockOverlay from './pages/overlay/ClockOverlay';
 import BarOverlay from './pages/overlay/BarOverlay';
 import PauseOverlay from './pages/overlay/PauseOverlay';
 import AlertOverlay from './pages/overlay/AlertOverlay';
+import BorderOverlay from './pages/overlay/BorderOverlay';
 import NavMenu from './components/NavMenu';
 import './styles/ServerPages.css';
 
@@ -31,7 +32,7 @@ const ALLOW_NO_TOKEN = [
 
 // Overlay paths: invalid/expired token shows an inline message instead of redirecting,
 // since OBS Browser Sources can't interact with a Twitch auth flow.
-const OVERLAY_PATHS = ['/chat', '/clock', '/bar', '/pause', '/alerts'];
+const OVERLAY_PATHS = ['/chat', '/clock', '/bar', '/pause', '/alerts', '/border'];
 
 // Shown inside an overlay when the token is missing or expired
 function OverlayExpired() {
@@ -187,6 +188,7 @@ function App() {
                   <Route path="/bar" element={<BarOverlay />} />
                   <Route path="/pause" element={<PauseOverlay />} />
                   <Route path="/alerts" element={<AlertOverlay />} />
+                  <Route path="/border" element={<BorderOverlay />} />
                   <Route path="*" element={<NotFoundPage />} />
                 </Routes>
               </div>

--- a/src/components/NavMenu.tsx
+++ b/src/components/NavMenu.tsx
@@ -8,12 +8,13 @@ const NAV_ITEMS = [
   { path: '/chat', label: '💬 Chat' },
   { path: '/clock', label: '🕐 Clock' },
   { path: '/bar', label: '📊 Bar' },
+  { path: '/border', label: '🖼 Border' },
   { path: '/pause', label: '⏸ Pause' },
   { path: '/alerts', label: '🔔 Alerts' },
   { path: '/demo', label: '🧪 Demo' },
 ];
 
-const OVERLAY_PATHS = ['/chat', '/clock', '/bar', '/pause', '/alerts'];
+const OVERLAY_PATHS = ['/chat', '/clock', '/bar', '/pause', '/alerts', '/border'];
 
 export default function NavMenu() {
   const { settings } = useSettings();

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -101,6 +101,15 @@ function parseUrlOverrides(search: string): Partial<OverlaySettings> {
       },
     } as OverlaySettings['themeSettings'];
   }
+  if (p.has('showBarOrnaments')) {
+    o.themeSettings = {
+      ...(o.themeSettings ?? {}),
+      y2k: {
+        ...(o.themeSettings?.y2k ?? {}),
+        showBarOrnaments: p.get('showBarOrnaments') !== 'false',
+      },
+    } as OverlaySettings['themeSettings'];
+  }
   if (p.has('hideBackground')) o.hideBackground = p.get('hideBackground') !== 'false';
   if (p.has('hideContent')) o.hideContent = p.get('hideContent') !== 'false';
 

--- a/src/pages/AuthSuccessPage.tsx
+++ b/src/pages/AuthSuccessPage.tsx
@@ -667,12 +667,20 @@ export default function AuthSuccessPage() {
                 </>
               )}
               {persistedSettings.theme === 'y2k' && (
-                <Switch
-                  label="Reduced effects"
-                  description="Use static ornaments and title treatment instead of animated shader effects for better OBS stability."
-                  checked={y2k.reducedEffects}
-                  onChange={(e) => save({ themeSettings: { y2k: { reducedEffects: e.currentTarget.checked } } as typeof persistedSettings.themeSettings })}
-                />
+                <>
+                  <Switch
+                    label="Reduced effects"
+                    description="Use static ornaments and title treatment instead of animated shader effects for better OBS stability."
+                    checked={y2k.reducedEffects}
+                    onChange={(e) => save({ themeSettings: { y2k: { reducedEffects: e.currentTarget.checked } } as typeof persistedSettings.themeSettings })}
+                  />
+                  <Switch
+                    label="Show bar ornaments"
+                    description="Show decorative Y2K ornaments on the bar overlay. Disable this when using the border overlay instead."
+                    checked={y2k.showBarOrnaments}
+                    onChange={(e) => save({ themeSettings: { y2k: { showBarOrnaments: e.currentTarget.checked } } as typeof persistedSettings.themeSettings })}
+                  />
+                </>
               )}
             </Stack>
           )}

--- a/src/pages/AuthSuccessPage.tsx
+++ b/src/pages/AuthSuccessPage.tsx
@@ -259,7 +259,7 @@ export default function AuthSuccessPage() {
             </Text>
             <Text size="xs" c="dimmed" component="div" mt={4}>
               <strong>Other</strong>:{' '}
-              <code>?overlayOpacity=0.9&amp;fontSize=1.2&amp;barFloating=false&amp;theme=y2k&amp;reducedEffects=true&amp;hideBackground=true&amp;hideContent=true</code>
+              <code>?overlayOpacity=0.9&amp;fontSize=1.2&amp;barFloating=false&amp;theme=y2k&amp;reducedEffects=true&amp;showBarOrnaments=false&amp;hideBackground=true&amp;hideContent=true</code>
             </Text>
           </details>
         </Paper>

--- a/src/pages/overlay/BarOverlay.tsx
+++ b/src/pages/overlay/BarOverlay.tsx
@@ -11,6 +11,7 @@ const BarOverlayContent = () => {
   const { settings, isLoadingSettings } = useSettings();
   const twitch = TwitchProvider.useTwitch();
   const reducedEffects = settings.themeSettings.y2k.reducedEffects;
+  const showBarOrnaments = settings.themeSettings.y2k.showBarOrnaments;
   const overlayRef = useRef<HTMLDivElement>(null);
   const [currentTime, setCurrentTime] = useState(new Date());
   const [overlayWidth, setOverlayWidth] = useState(0);
@@ -211,7 +212,7 @@ const BarOverlayContent = () => {
     >
       <ThemeBackground panelMode />
 
-      {settings.theme === 'y2k' && (
+      {settings.theme === 'y2k' && showBarOrnaments && (
         <>
           <BarY2KOrnament staticMode={reducedEffects} />
           <BarY2KOrnament src="/tribal_center.png" center height={65} yOffset={-72} staticMode={reducedEffects} />

--- a/src/pages/overlay/BorderOverlay.tsx
+++ b/src/pages/overlay/BorderOverlay.tsx
@@ -95,7 +95,9 @@ const BorderOverlay = () => {
           <BorderStarCanvas className="border-overlay__star border-overlay__star--top-right" />
           <BorderStarCanvas className="border-overlay__star border-overlay__star--bottom-left" />
           <BorderStarCanvas className="border-overlay__star border-overlay__star--bottom-right" />
+          <BorderStarCanvas className="border-overlay__star border-overlay__star--top-center-left" size={26} />
           <BorderStarCanvas className="border-overlay__star border-overlay__star--top-center" size={48} />
+          <BorderStarCanvas className="border-overlay__star border-overlay__star--top-center-right" size={26} />
         </>
       )}
 

--- a/src/pages/overlay/BorderOverlay.tsx
+++ b/src/pages/overlay/BorderOverlay.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useRef } from 'react';
+import { useSettings } from '../../contexts/SettingsContext';
+import GlobalAlertLayer from '../../components/GlobalAlertLayer';
+import '../../styles/BorderOverlay.css';
+
+interface BorderStarCanvasProps {
+  className: string;
+  size?: number;
+}
+
+function BorderStarCanvas({ className, size = 44 }: BorderStarCanvasProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.round(size * dpr);
+    canvas.height = Math.round(size * dpr);
+    canvas.style.width = `${size}px`;
+    canvas.style.height = `${size}px`;
+
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.scale(dpr, dpr);
+    ctx.clearRect(0, 0, size, size);
+
+    const center = size / 2;
+    const arm = size * 0.46;
+    const inner = size * 0.15;
+    const curve = inner * 1.45;
+
+    // Four-point star built as a rounded-intersection cross.
+    ctx.beginPath();
+    ctx.moveTo(center, center - arm);
+    ctx.quadraticCurveTo(center + inner * 0.4, center - curve, center + inner, center - inner);
+    ctx.lineTo(center + arm, center);
+    ctx.quadraticCurveTo(center + curve, center + inner * 0.4, center + inner, center + inner);
+    ctx.lineTo(center, center + arm);
+    ctx.quadraticCurveTo(center - inner * 0.4, center + curve, center - inner, center + inner);
+    ctx.lineTo(center - arm, center);
+    ctx.quadraticCurveTo(center - curve, center - inner * 0.4, center - inner, center - inner);
+    ctx.closePath();
+
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.94)';
+    ctx.shadowColor = 'rgba(196, 214, 255, 0.55)';
+    ctx.shadowBlur = size * 0.18;
+    ctx.fill();
+  }, [size]);
+
+  return <canvas ref={canvasRef} className={className} aria-hidden="true" />;
+}
+
+const BorderOverlay = () => {
+  const { settings, isLoadingSettings } = useSettings();
+
+  if (isLoadingSettings) return null;
+
+  const bottomOffset = settings.barFloating ? 80 : 60;
+  const overlayStyle = {
+    opacity: settings.overlayOpacity,
+    fontSize: `${settings.fontSize}rem`,
+    '--border-bottom-offset': `${bottomOffset}px`,
+  } as React.CSSProperties;
+
+  return (
+    <div
+      className={`border-overlay${settings.theme === 'crt' ? ' crt-active' : ''}${settings.theme === 'y2k' ? ' y2k-active' : ''}`}
+      style={overlayStyle}
+    >
+      <div className="border-overlay__frame" />
+
+      {settings.theme === 'y2k' && (
+        <>
+          <BorderStarCanvas className="border-overlay__star border-overlay__star--top-left" />
+          <BorderStarCanvas className="border-overlay__star border-overlay__star--top-right" />
+          <BorderStarCanvas className="border-overlay__star border-overlay__star--bottom-left" />
+          <BorderStarCanvas className="border-overlay__star border-overlay__star--bottom-right" />
+          <BorderStarCanvas className="border-overlay__star border-overlay__star--top-center" size={48} />
+        </>
+      )}
+
+      <GlobalAlertLayer />
+    </div>
+  );
+};
+
+export default BorderOverlay;

--- a/src/pages/overlay/BorderOverlay.tsx
+++ b/src/pages/overlay/BorderOverlay.tsx
@@ -116,14 +116,7 @@ const BorderOverlay = () => {
           preserveAspectRatio="none"
           viewBox="0 0 1000 1000"
         >
-          <rect
-            x="10"
-            y="10"
-            width="980"
-            height="980"
-            rx="0"
-            ry="0"
-          />
+          <rect x="0" y="0" width="1000" height="1000" />
         </svg>
       ) : (
         <div className="border-overlay__frame" />

--- a/src/pages/overlay/BorderOverlay.tsx
+++ b/src/pages/overlay/BorderOverlay.tsx
@@ -77,7 +77,7 @@ const BorderOverlay = () => {
 
   if (isLoadingSettings) return null;
 
-  const bottomOffset = settings.barFloating ? 80 : 60;
+  const bottomOffset = settings.barFloating ? 90 : 70;
   const overlayStyle = {
     opacity: settings.overlayOpacity,
     fontSize: `${settings.fontSize}rem`,

--- a/src/pages/overlay/BorderOverlay.tsx
+++ b/src/pages/overlay/BorderOverlay.tsx
@@ -29,20 +29,26 @@ function BorderStarCanvas({ className, size = 44 }: BorderStarCanvasProps) {
     ctx.clearRect(0, 0, size, size);
 
     const center = size / 2;
-    const arm = size * 0.46;
-    const inner = size * 0.15;
-    const curve = inner * 1.45;
+    const top = size * 0.04;
+    const right = size * 0.96;
+    const bottom = size * 0.98;
+    const left = size * 0.06;
+    const upperShoulder = size * 0.30;
+    const lowerShoulder = size * 0.70;
+    const upperInner = size * 0.19;
+    const lowerInner = size * 0.81;
 
-    // Four-point star built as a rounded-intersection cross.
+    // Four-point star with sharper inner corners and a slight asymmetry so it
+    // feels hand-cut rather than mechanically mirrored.
     ctx.beginPath();
-    ctx.moveTo(center, center - arm);
-    ctx.quadraticCurveTo(center + inner * 0.4, center - curve, center + inner, center - inner);
-    ctx.lineTo(center + arm, center);
-    ctx.quadraticCurveTo(center + curve, center + inner * 0.4, center + inner, center + inner);
-    ctx.lineTo(center, center + arm);
-    ctx.quadraticCurveTo(center - inner * 0.4, center + curve, center - inner, center + inner);
-    ctx.lineTo(center - arm, center);
-    ctx.quadraticCurveTo(center - curve, center - inner * 0.4, center - inner, center - inner);
+    ctx.moveTo(center, top);
+    ctx.lineTo(center + size * 0.11, upperShoulder);
+    ctx.lineTo(right, center);
+    ctx.lineTo(center + size * 0.15, lowerShoulder);
+    ctx.lineTo(center, bottom);
+    ctx.lineTo(center - size * 0.14, lowerInner);
+    ctx.lineTo(left, center - size * 0.02);
+    ctx.lineTo(center - size * 0.12, upperInner);
     ctx.closePath();
 
     ctx.fillStyle = 'rgba(255, 255, 255, 0.94)';
@@ -56,6 +62,25 @@ function BorderStarCanvas({ className, size = 44 }: BorderStarCanvasProps) {
 
 const BorderOverlay = () => {
   const { settings, isLoadingSettings } = useSettings();
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const root = overlayRef.current;
+    if (!root || settings.theme !== 'y2k') return;
+
+    let frame = 0;
+    const apply = (now: number) => {
+      const t = now / 1000;
+      root.style.setProperty('--border-drift-a', `${Math.sin(t * 0.17) * 0.45}px`);
+      root.style.setProperty('--border-drift-b', `${Math.sin(t * 0.23 + 1.3) * 0.35}px`);
+      root.style.setProperty('--border-drift-c', `${Math.sin(t * 0.13 + 2.1) * 0.25}px`);
+      root.style.setProperty('--border-drift-d', `${Math.sin(t * 0.19 + 0.7) * 0.2}px`);
+      frame = window.requestAnimationFrame(apply);
+    };
+
+    frame = window.requestAnimationFrame(apply);
+    return () => window.cancelAnimationFrame(frame);
+  }, [settings.theme]);
 
   if (isLoadingSettings) return null;
 
@@ -68,10 +93,29 @@ const BorderOverlay = () => {
 
   return (
     <div
+      ref={overlayRef}
       className={`border-overlay${settings.theme === 'crt' ? ' crt-active' : ''}${settings.theme === 'y2k' ? ' y2k-active' : ''}`}
       style={overlayStyle}
     >
-      <div className="border-overlay__frame" />
+      {settings.theme === 'y2k' ? (
+        <svg
+          className="border-overlay__frame border-overlay__frame--y2k"
+          aria-hidden="true"
+          preserveAspectRatio="none"
+          viewBox="0 0 1000 1000"
+        >
+          <rect
+            x="10"
+            y="10"
+            width="980"
+            height="980"
+            rx="0"
+            ry="0"
+          />
+        </svg>
+      ) : (
+        <div className="border-overlay__frame" />
+      )}
 
       {settings.theme === 'y2k' && (
         <>

--- a/src/pages/overlay/BorderOverlay.tsx
+++ b/src/pages/overlay/BorderOverlay.tsx
@@ -8,6 +8,23 @@ interface BorderStarCanvasProps {
   size?: number;
 }
 
+type NormalizedPoint = { x: number; y: number };
+
+const STAR_POINTS = {
+  top: { x: 0.50, y: 0.12 },
+  pairTR: { x: 0.55, y: 0.45 },
+  right: { x: 0.88, y: 0.50 },
+  pairBR: { x: 0.55, y: 0.55 },
+  bottom: { x: 0.50, y: 0.88 },
+  pairBL: { x: 0.45, y: 0.55 },
+  left: { x: 0.12, y: 0.50 },
+  pairTL: { x: 0.45, y: 0.45 },
+} as const;
+
+function toPoint(size: number, point: NormalizedPoint) {
+  return { x: point.x * size, y: point.y * size };
+}
+
 function BorderStarCanvas({ className, size = 44 }: BorderStarCanvasProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
@@ -28,27 +45,22 @@ function BorderStarCanvas({ className, size = 44 }: BorderStarCanvasProps) {
     ctx.scale(dpr, dpr);
     ctx.clearRect(0, 0, size, size);
 
-    const center = size / 2;
-    const top = size * 0.04;
-    const right = size * 0.96;
-    const bottom = size * 0.98;
-    const left = size * 0.06;
-    const upperShoulder = size * 0.30;
-    const lowerShoulder = size * 0.70;
-    const upperInner = size * 0.19;
-    const lowerInner = size * 0.81;
+    const top = toPoint(size, STAR_POINTS.top);
+    const pairTR = toPoint(size, STAR_POINTS.pairTR);
+    const right = toPoint(size, STAR_POINTS.right);
+    const pairBR = toPoint(size, STAR_POINTS.pairBR);
+    const bottom = toPoint(size, STAR_POINTS.bottom);
+    const pairBL = toPoint(size, STAR_POINTS.pairBL);
+    const left = toPoint(size, STAR_POINTS.left);
+    const pairTL = toPoint(size, STAR_POINTS.pairTL);
 
-    // Four-point star with sharper inner corners and a slight asymmetry so it
-    // feels hand-cut rather than mechanically mirrored.
+    // Four cubic Beziers, one for each arm, with sharp anchor tips.
     ctx.beginPath();
-    ctx.moveTo(center, top);
-    ctx.lineTo(center + size * 0.11, upperShoulder);
-    ctx.lineTo(right, center);
-    ctx.lineTo(center + size * 0.15, lowerShoulder);
-    ctx.lineTo(center, bottom);
-    ctx.lineTo(center - size * 0.14, lowerInner);
-    ctx.lineTo(left, center - size * 0.02);
-    ctx.lineTo(center - size * 0.12, upperInner);
+    ctx.moveTo(top.x, top.y);
+    ctx.bezierCurveTo(pairTR.x, pairTR.y, pairTR.x, pairTR.y, right.x, right.y);
+    ctx.bezierCurveTo(pairBR.x, pairBR.y, pairBR.x, pairBR.y, bottom.x, bottom.y);
+    ctx.bezierCurveTo(pairBL.x, pairBL.y, pairBL.x, pairBL.y, left.x, left.y);
+    ctx.bezierCurveTo(pairTL.x, pairTL.y, pairTL.x, pairTL.y, top.x, top.y);
     ctx.closePath();
 
     ctx.fillStyle = 'rgba(255, 255, 255, 0.94)';

--- a/src/pages/overlay/BorderOverlay.tsx
+++ b/src/pages/overlay/BorderOverlay.tsx
@@ -74,25 +74,6 @@ function BorderStarCanvas({ className, size = 44 }: BorderStarCanvasProps) {
 
 const BorderOverlay = () => {
   const { settings, isLoadingSettings } = useSettings();
-  const overlayRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const root = overlayRef.current;
-    if (!root || settings.theme !== 'y2k') return;
-
-    let frame = 0;
-    const apply = (now: number) => {
-      const t = now / 1000;
-      root.style.setProperty('--border-drift-a', `${Math.sin(t * 0.17) * 0.45}px`);
-      root.style.setProperty('--border-drift-b', `${Math.sin(t * 0.23 + 1.3) * 0.35}px`);
-      root.style.setProperty('--border-drift-c', `${Math.sin(t * 0.13 + 2.1) * 0.25}px`);
-      root.style.setProperty('--border-drift-d', `${Math.sin(t * 0.19 + 0.7) * 0.2}px`);
-      frame = window.requestAnimationFrame(apply);
-    };
-
-    frame = window.requestAnimationFrame(apply);
-    return () => window.cancelAnimationFrame(frame);
-  }, [settings.theme]);
 
   if (isLoadingSettings) return null;
 
@@ -105,12 +86,9 @@ const BorderOverlay = () => {
 
   return (
     <div
-      ref={overlayRef}
       className={`border-overlay${settings.theme === 'crt' ? ' crt-active' : ''}${settings.theme === 'y2k' ? ' y2k-active' : ''}`}
       style={overlayStyle}
     >
-      <div className="border-overlay__frame" />
-
       {settings.theme === 'y2k' && (
         <>
           <BorderStarCanvas className="border-overlay__star border-overlay__star--top-left" />

--- a/src/pages/overlay/BorderOverlay.tsx
+++ b/src/pages/overlay/BorderOverlay.tsx
@@ -109,18 +109,7 @@ const BorderOverlay = () => {
       className={`border-overlay${settings.theme === 'crt' ? ' crt-active' : ''}${settings.theme === 'y2k' ? ' y2k-active' : ''}`}
       style={overlayStyle}
     >
-      {settings.theme === 'y2k' ? (
-        <svg
-          className="border-overlay__frame border-overlay__frame--y2k"
-          aria-hidden="true"
-          preserveAspectRatio="none"
-          viewBox="0 0 1000 1000"
-        >
-          <rect x="0" y="0" width="1000" height="1000" />
-        </svg>
-      ) : (
-        <div className="border-overlay__frame" />
-      )}
+      <div className="border-overlay__frame" />
 
       {settings.theme === 'y2k' && (
         <>

--- a/src/server/settings.ts
+++ b/src/server/settings.ts
@@ -252,6 +252,13 @@ router.patch('/', express.json(), (req: Request, res: Response) => {
               y2kPatch.reducedEffects = y.reducedEffects;
             }
           }
+          if ('showBarOrnaments' in y) {
+            if (typeof y.showBarOrnaments !== 'boolean') {
+              errors.push('themeSettings.y2k.showBarOrnaments must be a boolean');
+            } else {
+              y2kPatch.showBarOrnaments = y.showBarOrnaments;
+            }
+          }
           if (Object.keys(y2kPatch).length > 0) themePatch.y2k = y2kPatch;
         }
       }

--- a/src/server/shared/overlaySettings.ts
+++ b/src/server/shared/overlaySettings.ts
@@ -62,6 +62,7 @@ export interface OverlaySettings {
     };
     y2k: {
       reducedEffects: boolean;
+      showBarOrnaments: boolean;
     };
   };
   pauseTitle: string;
@@ -90,6 +91,7 @@ export const defaultOverlaySettings: OverlaySettings = {
     },
     y2k: {
       reducedEffects: false,
+      showBarOrnaments: true,
     },
   },
   pauseTitle: 'En pause',

--- a/src/styles/BorderOverlay.css
+++ b/src/styles/BorderOverlay.css
@@ -12,7 +12,7 @@
   top: 1.2rem;
   left: 1.2rem;
   right: 1.2rem;
-  bottom: var(--border-bottom-offset, 80px);
+  bottom: var(--border-bottom-offset, 90px);
   border-radius: 1px;
   opacity: 0;
 }
@@ -44,12 +44,12 @@
 }
 
 .border-overlay__star--bottom-left {
-  bottom: calc(var(--border-bottom-offset, 80px) - 22px);
+  bottom: calc(var(--border-bottom-offset, 90px) - 22px);
   left: calc(1.2rem - 22px);
 }
 
 .border-overlay__star--bottom-right {
-  bottom: calc(var(--border-bottom-offset, 80px) - 22px);
+  bottom: calc(var(--border-bottom-offset, 90px) - 22px);
   right: calc(1.2rem - 22px);
 }
 
@@ -99,12 +99,12 @@
   }
 
   .border-overlay__star--bottom-left {
-    bottom: calc(var(--border-bottom-offset, 80px) - 20px);
+    bottom: calc(var(--border-bottom-offset, 90px) - 20px);
     left: calc(0.85rem - 20px);
   }
 
   .border-overlay__star--bottom-right {
-    bottom: calc(var(--border-bottom-offset, 80px) - 20px);
+    bottom: calc(var(--border-bottom-offset, 90px) - 20px);
     right: calc(0.85rem - 20px);
   }
 

--- a/src/styles/BorderOverlay.css
+++ b/src/styles/BorderOverlay.css
@@ -14,11 +14,14 @@
   right: 1.2rem;
   bottom: var(--border-bottom-offset, 90px);
   border-radius: 1px;
-  opacity: 0;
+}
+
+.border-overlay:not(.y2k-active)::before {
+  border: 1px solid rgba(255, 255, 255, 0.85);
 }
 
 .border-overlay.y2k-active::before {
-  opacity: 1;
+  border: none;
   box-shadow:
     0 0 18px rgba(188, 204, 255, 0.24),
     0 0 10px rgba(255, 255, 255, 0.12),

--- a/src/styles/BorderOverlay.css
+++ b/src/styles/BorderOverlay.css
@@ -36,9 +36,6 @@
 
 .border-overlay.y2k-active .border-overlay__frame {
   border-color: rgba(255, 255, 255, 0.9);
-  box-shadow:
-    0 0 16px rgba(188, 204, 255, 0.22),
-    0 0 3px rgba(255, 255, 255, 0.8) inset;
 }
 
 .border-overlay__star {

--- a/src/styles/BorderOverlay.css
+++ b/src/styles/BorderOverlay.css
@@ -16,26 +16,11 @@
   border-radius: 1px;
 }
 
-.border-overlay__frame--y2k {
-  border: none;
-  overflow: visible;
-  filter: drop-shadow(0 0 7px rgba(214, 225, 255, 0.32));
-}
-
-.border-overlay__frame--y2k rect {
-  fill: none;
-  stroke: rgba(255, 255, 255, 0.9);
-  stroke-width: 2.2;
-  vector-effect: non-scaling-stroke;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  stroke-dasharray: 14 6 8 4 21 8 13 5 8 4 13 6 21 8 34 11 21 8 13 5 8 4 13 6 21 8 8 4 14 6;
-  stroke-dashoffset: 0;
-  animation: border-dash-drift 26s linear infinite;
-}
-
 .border-overlay.y2k-active .border-overlay__frame {
   border-color: rgba(255, 255, 255, 0.9);
+  box-shadow:
+    0 0 16px rgba(188, 204, 255, 0.22),
+    0 0 3px rgba(255, 255, 255, 0.8) inset;
 }
 
 .border-overlay__star {
@@ -107,14 +92,5 @@
   .border-overlay__star--bottom-right {
     bottom: calc(var(--border-bottom-offset, 80px) - 20px);
     right: calc(0.85rem - 20px);
-  }
-}
-
-@keyframes border-dash-drift {
-  from {
-    stroke-dashoffset: 0;
-  }
-  to {
-    stroke-dashoffset: -120;
   }
 }

--- a/src/styles/BorderOverlay.css
+++ b/src/styles/BorderOverlay.css
@@ -16,6 +16,24 @@
   border-radius: 1px;
 }
 
+.border-overlay__frame--y2k {
+  border: none;
+  overflow: visible;
+  filter: drop-shadow(0 0 7px rgba(214, 225, 255, 0.32));
+}
+
+.border-overlay__frame--y2k rect {
+  fill: none;
+  stroke: rgba(255, 255, 255, 0.9);
+  stroke-width: 2.2;
+  vector-effect: non-scaling-stroke;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-dasharray: 14 6 8 4 21 8 13 5 8 4 13 6 21 8 34 11 21 8 13 5 8 4 13 6 21 8 8 4 14 6;
+  stroke-dashoffset: 0;
+  animation: border-dash-drift 26s linear infinite;
+}
+
 .border-overlay.y2k-active .border-overlay__frame {
   border-color: rgba(255, 255, 255, 0.9);
   box-shadow:
@@ -34,21 +52,25 @@
 .border-overlay__star--top-left {
   top: calc(1.2rem - 22px);
   left: calc(1.2rem - 22px);
+  transform: translate(var(--border-drift-a, 0px), var(--border-drift-c, 0px));
 }
 
 .border-overlay__star--top-right {
   top: calc(1.2rem - 22px);
   right: calc(1.2rem - 22px);
+  transform: translate(var(--border-drift-b, 0px), var(--border-drift-a, 0px));
 }
 
 .border-overlay__star--bottom-left {
   bottom: calc(var(--border-bottom-offset, 80px) - 22px);
   left: calc(1.2rem - 22px);
+  transform: translate(var(--border-drift-c, 0px), var(--border-drift-b, 0px));
 }
 
 .border-overlay__star--bottom-right {
   bottom: calc(var(--border-bottom-offset, 80px) - 22px);
   right: calc(1.2rem - 22px);
+  transform: translate(var(--border-drift-d, 0px), var(--border-drift-c, 0px));
 }
 
 .border-overlay__star--top-center {
@@ -88,5 +110,14 @@
   .border-overlay__star--bottom-right {
     bottom: calc(var(--border-bottom-offset, 80px) - 20px);
     right: calc(0.85rem - 20px);
+  }
+}
+
+@keyframes border-dash-drift {
+  from {
+    stroke-dashoffset: 0;
+  }
+  to {
+    stroke-dashoffset: -120;
   }
 }

--- a/src/styles/BorderOverlay.css
+++ b/src/styles/BorderOverlay.css
@@ -1,0 +1,92 @@
+.border-overlay {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  isolation: isolate;
+  z-index: 900;
+}
+
+.border-overlay__frame {
+  position: absolute;
+  top: 1.2rem;
+  left: 1.2rem;
+  right: 1.2rem;
+  bottom: var(--border-bottom-offset, 80px);
+  border: 1px solid rgba(255, 255, 255, 0.82);
+  border-radius: 1px;
+}
+
+.border-overlay.y2k-active .border-overlay__frame {
+  border-color: rgba(255, 255, 255, 0.9);
+  box-shadow:
+    0 0 16px rgba(188, 204, 255, 0.22),
+    0 0 3px rgba(255, 255, 255, 0.8) inset;
+}
+
+.border-overlay__star {
+  position: absolute;
+  width: 44px;
+  height: 44px;
+  pointer-events: none;
+  filter: drop-shadow(0 0 8px rgba(230, 239, 255, 0.45));
+}
+
+.border-overlay__star--top-left {
+  top: calc(1.2rem - 22px);
+  left: calc(1.2rem - 22px);
+}
+
+.border-overlay__star--top-right {
+  top: calc(1.2rem - 22px);
+  right: calc(1.2rem - 22px);
+}
+
+.border-overlay__star--bottom-left {
+  bottom: calc(var(--border-bottom-offset, 80px) - 22px);
+  left: calc(1.2rem - 22px);
+}
+
+.border-overlay__star--bottom-right {
+  bottom: calc(var(--border-bottom-offset, 80px) - 22px);
+  right: calc(1.2rem - 22px);
+}
+
+.border-overlay__star--top-center {
+  top: calc(1.2rem - 24px);
+  left: 50%;
+  width: 48px;
+  height: 48px;
+  transform: translateX(-50%);
+}
+
+.border-overlay:not(.y2k-active) .border-overlay__star {
+  display: none;
+}
+
+@media (max-width: 900px) {
+  .border-overlay__frame {
+    top: 0.85rem;
+    left: 0.85rem;
+    right: 0.85rem;
+  }
+
+  .border-overlay__star--top-left {
+    top: calc(0.85rem - 20px);
+    left: calc(0.85rem - 20px);
+  }
+
+  .border-overlay__star--top-right {
+    top: calc(0.85rem - 20px);
+    right: calc(0.85rem - 20px);
+  }
+
+  .border-overlay__star--bottom-left {
+    bottom: calc(var(--border-bottom-offset, 80px) - 20px);
+    left: calc(0.85rem - 20px);
+  }
+
+  .border-overlay__star--bottom-right {
+    bottom: calc(var(--border-bottom-offset, 80px) - 20px);
+    right: calc(0.85rem - 20px);
+  }
+}

--- a/src/styles/BorderOverlay.css
+++ b/src/styles/BorderOverlay.css
@@ -61,6 +61,22 @@
   transform: translateX(-50%);
 }
 
+.border-overlay__star--top-center-left {
+  top: calc(1.2rem - 13px);
+  left: calc(50% - 42px);
+  width: 26px;
+  height: 26px;
+  transform: translateX(-50%);
+}
+
+.border-overlay__star--top-center-right {
+  top: calc(1.2rem - 13px);
+  left: calc(50% + 42px);
+  width: 26px;
+  height: 26px;
+  transform: translateX(-50%);
+}
+
 .border-overlay:not(.y2k-active) .border-overlay__star {
   display: none;
 }
@@ -90,5 +106,19 @@
   .border-overlay__star--bottom-right {
     bottom: calc(var(--border-bottom-offset, 80px) - 20px);
     right: calc(0.85rem - 20px);
+  }
+
+  .border-overlay__star--top-center {
+    top: calc(0.85rem - 24px);
+  }
+
+  .border-overlay__star--top-center-left {
+    top: calc(0.85rem - 13px);
+    left: calc(50% - 36px);
+  }
+
+  .border-overlay__star--top-center-right {
+    top: calc(0.85rem - 13px);
+    left: calc(50% + 36px);
   }
 }

--- a/src/styles/BorderOverlay.css
+++ b/src/styles/BorderOverlay.css
@@ -6,21 +6,23 @@
   z-index: 900;
 }
 
-.border-overlay__frame {
+.border-overlay::before {
+  content: '';
   position: absolute;
   top: 1.2rem;
   left: 1.2rem;
   right: 1.2rem;
   bottom: var(--border-bottom-offset, 80px);
-  border: 1px solid rgba(255, 255, 255, 0.82);
   border-radius: 1px;
+  opacity: 0;
 }
 
-.border-overlay.y2k-active .border-overlay__frame {
-  border-color: rgba(255, 255, 255, 0.9);
+.border-overlay.y2k-active::before {
+  opacity: 1;
   box-shadow:
-    0 0 16px rgba(188, 204, 255, 0.22),
-    0 0 3px rgba(255, 255, 255, 0.8) inset;
+    0 0 18px rgba(188, 204, 255, 0.24),
+    0 0 10px rgba(255, 255, 255, 0.12),
+    inset 0 0 12px rgba(255, 255, 255, 0.12);
 }
 
 .border-overlay__star {
@@ -34,25 +36,21 @@
 .border-overlay__star--top-left {
   top: calc(1.2rem - 22px);
   left: calc(1.2rem - 22px);
-  transform: translate(var(--border-drift-a, 0px), var(--border-drift-c, 0px));
 }
 
 .border-overlay__star--top-right {
   top: calc(1.2rem - 22px);
   right: calc(1.2rem - 22px);
-  transform: translate(var(--border-drift-b, 0px), var(--border-drift-a, 0px));
 }
 
 .border-overlay__star--bottom-left {
   bottom: calc(var(--border-bottom-offset, 80px) - 22px);
   left: calc(1.2rem - 22px);
-  transform: translate(var(--border-drift-c, 0px), var(--border-drift-b, 0px));
 }
 
 .border-overlay__star--bottom-right {
   bottom: calc(var(--border-bottom-offset, 80px) - 22px);
   right: calc(1.2rem - 22px);
-  transform: translate(var(--border-drift-d, 0px), var(--border-drift-c, 0px));
 }
 
 .border-overlay__star--top-center {
@@ -68,7 +66,7 @@
 }
 
 @media (max-width: 900px) {
-  .border-overlay__frame {
+  .border-overlay::before {
     top: 0.85rem;
     left: 0.85rem;
     right: 0.85rem;


### PR DESCRIPTION
## Summary
- add a new standalone `/border` overlay route
- add Border entry to navigation and treat `/border` as an overlay path (token-expired inline UX + nav hidden)
- implement `BorderOverlay` with global settings behavior parity (uses global `overlayOpacity` and `fontSize`)
- implement Y2K-specific border ornaments using canvas-rendered rounded-cross stars at:
  - top-left
  - top-right
  - bottom-left
  - bottom-right
  - top-center
- implement non-Y2K fallback as a simple thin white rectangle
- align border bottom offset with bar behavior:
  - `barFloating=true` => 80px
  - `barFloating=false` => 60px

## Files
- `src/App.tsx`
- `src/components/NavMenu.tsx`
- `src/pages/overlay/BorderOverlay.tsx`
- `src/styles/BorderOverlay.css`

## Notes
- no new border-specific settings keys were introduced
- implementation follows existing overlay conventions and keeps pointer-events disabled

## Validation
- local type diagnostics clean for touched files
- pre-commit build hook passed (`tsc -b && vite build`)

## Staging test checklist
- open `/border?token=...` on staging
- verify Y2K theme shows thin white frame + 5 stars
- verify CRT/default themes show simple white rectangle
- verify bottom frame margin aligns with bar overlay for both `barFloating=true/false`
- verify opacity and font-size global settings apply as expected